### PR TITLE
Restore Appendix C

### DIFF
--- a/Standard/Figures/CoreASM/ArchitekturKonsoleCoreASM.pdf
+++ b/Standard/Figures/CoreASM/ArchitekturKonsoleCoreASM.pdf
@@ -8,8 +8,8 @@
       /Keywords ()
       /Creator (yExport 1.5)
       /Producer (org.freehep.graphicsio.pdf.YPDFGraphics2D 1.5)
-      /CreationDate (D:20190225180949+01'00')
-      /ModDate (D:20190225180949+01'00')
+      /CreationDate (D:20200815111750+02'00')
+      /ModDate (D:20200815111750+02'00')
       /Trapped /False
    >>
 endobj
@@ -76,7 +76,7 @@ W!<cMLgG'i".VUU7.8TCrP-gOdbk')i6565~>
 endstream
 endobj
 7 0 obj
-   2661
+   2629
 endobj
 8 0 obj
    << 
@@ -131,7 +131,7 @@ XCEND4@bRl`8-k,;SUJ%lDafHrW"1#M$F~>
 endstream
 endobj
 11 0 obj
-   1675
+   1655
 endobj
 12 0 obj
    << 
@@ -186,7 +186,7 @@ XCEND4@bRl`8-k,;SUJ%lDafHrW"1#M$F~>
 endstream
 endobj
 15 0 obj
-   1675
+   1655
 endobj
 16 0 obj
    << 
@@ -456,7 +456,7 @@ l?$1`~>
 endstream
 endobj
 250 0 obj
-   253
+   250
 endobj
 21 0 obj
    << 
@@ -469,7 +469,7 @@ G(ZrcTc$86fZ4V("e)hZ>T$d\>QEI*,>J~>
 endstream
 endobj
 251 0 obj
-   117
+   116
 endobj
 22 0 obj
    << 
@@ -482,7 +482,7 @@ TuFe]fiFbrV$X.%R^G.\)-gl\!7n"l8c~>
 endstream
 endobj
 252 0 obj
-   116
+   115
 endobj
 23 0 obj
    << 
@@ -495,7 +495,7 @@ GapQI0[MU0:]M(mb/h@,`7$TM0EKQjQH!=8WJ*?g:,1g]M*Mg:EhOr(iIVqu+TU&UK5O-g<sD_E(BDi,
 endstream
 endobj
 253 0 obj
-   87
+   86
 endobj
 24 0 obj
    << 
@@ -508,7 +508,7 @@ bu"Uahu`%1"qX.1=tg*;=u*V9\,_a>.5C~>
 endstream
 endobj
 254 0 obj
-   117
+   116
 endobj
 25 0 obj
    << 
@@ -522,7 +522,7 @@ Qr;Wf*GV2MUQ^FbDV@4$CV=toWa8XX*<ot'WLXA3=lV)oN5F"Ef,3+V]#j#De!>[5^EMR<h:uDu#sXT-
 endstream
 endobj
 255 0 obj
-   239
+   237
 endobj
 26 0 obj
    << 
@@ -538,7 +538,7 @@ Mgn-![J0%)9XgA_*r'<a9YV?gYcDU6XWGRf]6h0QqTM)tnT0'XqMCcG~>
 endstream
 endobj
 256 0 obj
-   385
+   381
 endobj
 27 0 obj
    << 
@@ -553,7 +553,7 @@ Xo~>
 endstream
 endobj
 257 0 obj
-   250
+   247
 endobj
 28 0 obj
    << 
@@ -578,7 +578,7 @@ aO%^>C+P7]+@@]anR3>VcqOKXR`5L2dI&H4~>
 endstream
 endobj
 259 0 obj
-   119
+   118
 endobj
 30 0 obj
    << 
@@ -591,7 +591,7 @@ Gar?*9+$2'$jHAc75*$9]`.8G6sR\-Df)k;d7jh"A4T#n0tK?a5_d__"r.V@;YXKLY"XfN2@#Lj?VDX8
 endstream
 endobj
 260 0 obj
-   123
+   122
 endobj
 31 0 obj
    << 
@@ -605,7 +605,7 @@ YQH@N.6A6U.R%L`j:gsI&+C#gO-3U'&(55!EX.l$nj(b,V;,SR_-aDVA(*>kec=2c/<.Kq!grctaW,ia
 endstream
 endobj
 261 0 obj
-   240
+   238
 endobj
 32 0 obj
    << 
@@ -623,7 +623,7 @@ h[TJQ`bFI0l/Q3"?,,6\Zu<UB"5*-i/;:R=U'GD/nEN+&V;MArVX)=]<OHX5[@bSj0<Zjs"qtlU.D()6
 endstream
 endobj
 262 0 obj
-   572
+   566
 endobj
 33 0 obj
    << 
@@ -643,7 +643,7 @@ o#<`WH/SWAi>k5a*rc7sGTBZ~>
 endstream
 endobj
 263 0 obj
-   682
+   674
 endobj
 34 0 obj
    << 
@@ -662,7 +662,7 @@ kd7tT-q20RjW3>%_ZI@#2*9+sF7nLNS)s,1nS2A>CD[=&rC;2PC&#im:GZ:d=2=Z^bbEl'"bgHNM[kl@
 endstream
 endobj
 264 0 obj
-   646
+   639
 endobj
 35 0 obj
    << 
@@ -675,7 +675,7 @@ GapRs0\/$6:bVk^5g%"N6n@Ji)hA,+$r%-rPcfil=Aar!Q_BNZZ:HU7WB!?O<$6r(c%m>lQlu_9<&8R)
 endstream
 endobj
 265 0 obj
-   96
+   95
 endobj
 36 0 obj
    << 
@@ -689,7 +689,7 @@ q>l"\.u<0]]Y%?WrdD]pDg9)7"t;^[~>
 endstream
 endobj
 266 0 obj
-   196
+   194
 endobj
 37 0 obj
    << 
@@ -703,7 +703,7 @@ AZEAILMQ1!P`^T^badbW)`DrW'0^R)4`U~>
 endstream
 endobj
 267 0 obj
-   199
+   197
 endobj
 38 0 obj
    << 
@@ -717,7 +717,7 @@ Gar'#3tB.^$q#60_A>b9Y<Vb1M@T(Qf@l@M\625XJKRCFZ6L\9B1V-`Be);3;ThusaYrf\+K50Hp]@pN
 endstream
 endobj
 268 0 obj
-   175
+   173
 endobj
 39 0 obj
    << 
@@ -730,7 +730,7 @@ GarW25n:[Q#R'V/_@P:LBT<%+RNC2_?OKmhd9bHZ@Bq0()ko\;&mR8a:HL(d7<dpOlHqm/3)ma32';$O
 endstream
 endobj
 269 0 obj
-   129
+   128
 endobj
 40 0 obj
    << 
@@ -743,7 +743,7 @@ GapQF1Y4E::bVk^5g%.Z6n@I>)Lt6c/M+]%OX5fU1$!on^uTRI$k5mm<9/!a%=n%%:^tW72^*r,K.Doh
 endstream
 endobj
 270 0 obj
-   91
+   90
 endobj
 41 0 obj
    << 
@@ -780,7 +780,7 @@ Q,/a*"TYTJ)-d~>
 endstream
 endobj
 273 0 obj
-   97
+   96
 endobj
 44 0 obj
    << 
@@ -797,7 +797,7 @@ eQr6\<iU<VSMWja*VT7ffVKS&'KLD31K.EpOX8afU<rN=.49b2?I-/!jYJ3iVDj&)Vl7pf/1?jr<]W.0
 endstream
 endobj
 274 0 obj
-   467
+   462
 endobj
 45 0 obj
    << 
@@ -811,7 +811,7 @@ aW);9.XN2O)?Z<E=I-mgV6WgBC"%MU/]%r1kkq<6Hj3euh,6E&@OkM0hW!<>A<;4(P+MsW[o0+O4m3>]
 endstream
 endobj
 275 0 obj
-   170
+   168
 endobj
 46 0 obj
    << 
@@ -827,7 +827,7 @@ g%==:HFE;9eU@Pi#CQO~>
 endstream
 endobj
 276 0 obj
-   349
+   345
 endobj
 47 0 obj
    << 
@@ -845,7 +845,7 @@ I.FlS)(@;jHD3HkX\'%S,dhdd?A$ZBf8kFd+DIFT"@?mjhTh;Ygl2)S2n+;C>CHtaj-knCKVQp2^7,D[
 endstream
 endobj
 277 0 obj
-   533
+   527
 endobj
 48 0 obj
    << 
@@ -859,7 +859,7 @@ OdjKJ2]&tGAm=kBV767%KRui;~>
 endstream
 endobj
 278 0 obj
-   191
+   189
 endobj
 49 0 obj
    << 
@@ -875,7 +875,7 @@ ba.C>iKNHjrD+b4pR@g>U-;Vf0<Sh<STYidk0].[E&V)tLDG[43;k3(iS$^P#SV&KaMt742kP^GWMrqO
 endstream
 endobj
 279 0 obj
-   393
+   389
 endobj
 50 0 obj
    << 
@@ -893,7 +893,7 @@ L-*uFk6:?Agi*F5=R^=VoEQKMUAc<,WYo[CUXA*U8KGbg&5$q_2.Z"']CD1R#i$@1XhX:q]8f3_]"3I)
 endstream
 endobj
 280 0 obj
-   556
+   550
 endobj
 51 0 obj
    << 
@@ -907,7 +907,7 @@ Gar&95n:dT%(k[;rP26c8RV"$2=83YIiTt7d9a'D3$sJ+#Nh$#dm0\gp+d:_;dPAPU`mtYmh3"CZ'*2^
 endstream
 endobj
 281 0 obj
-   176
+   174
 endobj
 52 0 obj
    << 
@@ -927,7 +927,7 @@ X(a[Kfe2._%>?PjAXY0lYPd+Xcggbf$%=W7<fYd`[]phJKYUBYX`Tt]Iu>Veo.$+Y]$p]8JY1eOh>rR%
 endstream
 endobj
 282 0 obj
-   658
+   650
 endobj
 53 0 obj
    << 
@@ -945,7 +945,7 @@ J)XPH+9~>
 endstream
 endobj
 283 0 obj
-   501
+   495
 endobj
 54 0 obj
    << 
@@ -958,7 +958,7 @@ GapQF1Y4E::bVk^5fs.%/*NF(=FrpM/W_8W%(W#40_nt`J?ae?LsFt2R=HF\eWPQ&7LiK(>fb:-*5u$Y
 endstream
 endobj
 284 0 obj
-   109
+   108
 endobj
 55 0 obj
    << 
@@ -971,7 +971,7 @@ I>"4)&XsXB2agFgPec9:'H=ttIFn6M!]C]1oR[nApaN?~>
 endstream
 endobj
 285 0 obj
-   128
+   127
 endobj
 56 0 obj
    << 
@@ -984,7 +984,7 @@ DBGqa2;H$O%Tm)EC>+1KfiS+=J."D#iM%Q,~>
 endstream
 endobj
 286 0 obj
-   119
+   118
 endobj
 57 0 obj
    << 
@@ -997,7 +997,7 @@ GapQI2V0`=:bVk^5g%^l6n@JiR".V"/4"Xe>pEhm&=m:O"]GC9ab:*>)h<(lE5D0S#XGfYTUV(]Q%:X.
 endstream
 endobj
 287 0 obj
-   114
+   113
 endobj
 58 0 obj
    << 
@@ -1010,7 +1010,7 @@ Gaqcn\IH>.#Xs*;n,eUmpgTl:9&]-o-6O:bL6%r*;%X>WUurCDW[ZPn:F`KIA0Ji,_)=8uIR(es(2tYE
 endstream
 endobj
 288 0 obj
-   119
+   118
 endobj
 59 0 obj
    << 
@@ -1026,7 +1026,7 @@ hQKfMA.8.\b=l6(1"GgXgIseq:n"f9MlXV14aduIjn7mgq2EOc2;?tBSlnR^UljAQ7NH'lL9;QdT#\.2
 endstream
 endobj
 289 0 obj
-   375
+   371
 endobj
 60 0 obj
    << 
@@ -1048,7 +1048,7 @@ bpUp=nbs9*pj)fA\PZ/f~>
 endstream
 endobj
 290 0 obj
-   842
+   832
 endobj
 61 0 obj
    << 
@@ -1062,7 +1062,7 @@ qK"<=T$c-eIMNhBTC;lNH:3)~>
 endstream
 endobj
 291 0 obj
-   190
+   188
 endobj
 62 0 obj
    << 
@@ -1079,7 +1079,7 @@ W`q%l/DP*EV0],>UD`cg0Y1YJ/9j:LHZ_TpmLI/J%lV$56F\iY)$:YY7V77%@.4,`eVlIW5WL!X3h`b9
 endstream
 endobj
 292 0 obj
-   464
+   459
 endobj
 63 0 obj
    << 
@@ -1095,7 +1095,7 @@ me`%C]2DH#.\Gf=_74iX~>
 endstream
 endobj
 293 0 obj
-   350
+   346
 endobj
 64 0 obj
    << 
@@ -1111,7 +1111,7 @@ Rm<iu`(gcER,K0/A_M_](pT&T1'!:[W%BCTg1`(8c5+056Ws\%\%-oS>g)pUF+hiL4@.1>X!\lKD<]_Z
 endstream
 endobj
 294 0 obj
-   379
+   375
 endobj
 65 0 obj
    << 
@@ -1124,7 +1124,7 @@ GapQI1=n<9:bVk^5g$qP6n@JiR=Re$bY4-E;[g319Yo^Bq-:F[.9NK7%[WlC+a*lr$VQ;+M6T&N!<W]d
 endstream
 endobj
 295 0 obj
-   129
+   128
 endobj
 66 0 obj
    << 
@@ -1137,7 +1137,7 @@ GapRp0[_a2:bVk^5g$qP6n@JiR@/[q9hYtW,Z>,^TE6hC>e#;5=JnIqQ_B*VFoc*?J;LN3%KQZ11bEAB
 endstream
 endobj
 296 0 obj
-   116
+   115
 endobj
 67 0 obj
    << 
@@ -1153,7 +1153,7 @@ TW8T]3K"Gm%B-Ni^XhsjhsIKC!3;<>;?~>
 endstream
 endobj
 297 0 obj
-   362
+   358
 endobj
 68 0 obj
    << 
@@ -1166,7 +1166,7 @@ kJOAhR"->fC]P9$>Db$5f7N.G*3K^Q1bJc(?S[]~>
 endstream
 endobj
 298 0 obj
-   123
+   122
 endobj
 69 0 obj
    << 
@@ -1193,7 +1193,7 @@ $!(@~>
 endstream
 endobj
 300 0 obj
-   252
+   249
 endobj
 71 0 obj
    << 
@@ -1207,7 +1207,7 @@ QrO8@R4'Csh%1pcQK0EC"R%J9VM83abI\Z:Z(#0E3IC1V5=4a[-ZJ0G"Xj!R,I$_s,Pq_II6!BnU=:_G
 endstream
 endobj
 301 0 obj
-   223
+   221
 endobj
 72 0 obj
    << 
@@ -1220,7 +1220,7 @@ GapRp0[MU0:]M(mb/+QT/*NFiR=dn%b`%Z0;[g2F/I_<6jE'8]@*1_XLC:*c6NCjj%N!V%F?[pi*-=8_
 endstream
 endobj
 302 0 obj
-   97
+   96
 endobj
 73 0 obj
    << 
@@ -1237,7 +1237,7 @@ HlYV>b09Mc^O=L7Vk%l1WI>SML4<c#>)pVoF%Hr.=!WBO#Vs5QAjXn5DR_hB56esKk)(ZcjqoH=1FqXu
 endstream
 endobj
 303 0 obj
-   429
+   424
 endobj
 74 0 obj
    << 
@@ -1251,7 +1251,7 @@ Gar&98IbhG%(k[;Hm"6,%GoR6l='PhCEYB3B.d;k9l0<n\Wg(50qd4<KP!DNU])W)#rZeg+1O?AOD^Dq
 endstream
 endobj
 304 0 obj
-   224
+   222
 endobj
 75 0 obj
    << 
@@ -1268,7 +1268,7 @@ o/gnW?0VpLoa,"TjMLZ<)$+Ip6/;RCVij15%NrIQ!#fG'-//84J<E/sQWPI`6EL>H.NO5Kqlj<e\:pun
 endstream
 endobj
 305 0 obj
-   430
+   425
 endobj
 76 0 obj
    << 
@@ -1284,7 +1284,7 @@ J]I~>
 endstream
 endobj
 306 0 obj
-   333
+   329
 endobj
 77 0 obj
    << 
@@ -1301,7 +1301,7 @@ I#WnXOU82DH1hX*d$eh3nNDR)cok.oh>RG'"0L#~>
 endstream
 endobj
 307 0 obj
-   451
+   446
 endobj
 78 0 obj
    << 
@@ -1317,7 +1317,7 @@ JJ'"WK#-!VT$bYrMaqdu\9"T9&-B0e:tiqj/j$`&j%]indiZ2tS9+~>
 endstream
 endobj
 308 0 obj
-   383
+   379
 endobj
 79 0 obj
    << 
@@ -1335,7 +1335,7 @@ hYB;eUZcZes,Qhg?gY2u!i^^bPQ~>
 endstream
 endobj
 309 0 obj
-   521
+   515
 endobj
 80 0 obj
    << 
@@ -1348,7 +1348,7 @@ GapQIZICZa:bVk^5fsL%l'e$.K1&FnN0,Aa%(W#40_nt`J>i]CX$R;_Z(VJ)!N6kr>XjI6f_>^]0K3AF
 endstream
 endobj
 310 0 obj
-   106
+   105
 endobj
 81 0 obj
    << 
@@ -1363,7 +1363,7 @@ Yf8o%T*5\Y^BC;p$/u5A2KAnP)1nM/P`ZI:Rl\<D*_p7-qR48p*?IWTi\ZQ)?0Z];)4XNiHA>HiQ_0%g
 endstream
 endobj
 311 0 obj
-   278
+   275
 endobj
 82 0 obj
    << 
@@ -1376,7 +1376,7 @@ Gar'#5n:gU#Y"KX_@(&8;dk!D2Nq:rqerNX9XGafrqesr<"j?2>,pX9dEEOeI&?BIqLao;Ui'+$+W)m3
 endstream
 endobj
 312 0 obj
-   161
+   160
 endobj
 83 0 obj
    << 
@@ -1391,7 +1391,7 @@ dMd74!i:n]=iOoP!]8RkVLZDDK@>-@pGpTmrSIOj=p\cDJTRJmSI?q_Wf>b!ZLlr_+PYjDB\`!mZ9>_[
 endstream
 endobj
 313 0 obj
-   287
+   284
 endobj
 84 0 obj
    << 
@@ -1404,7 +1404,7 @@ TX_R<W.U46*<K\l^c^St=kR`O-@Ba1'/Cn9&F)R*1jA"T4Rr<D^^18$,i(4C~>
 endstream
 endobj
 314 0 obj
-   144
+   143
 endobj
 85 0 obj
    << 
@@ -1418,7 +1418,7 @@ kR5643j8~>
 endstream
 endobj
 315 0 obj
-   174
+   172
 endobj
 86 0 obj
    << 
@@ -1433,7 +1433,7 @@ YP4*^0&_31qY\/5hs^far&A+5~>
 endstream
 endobj
 316 0 obj
-   273
+   270
 endobj
 87 0 obj
    << 
@@ -1446,7 +1446,7 @@ JBipQR=jp^*3K^Q1bJc`i$EI~>
 endstream
 endobj
 317 0 obj
-   108
+   107
 endobj
 88 0 obj
    << 
@@ -1459,7 +1459,7 @@ GapQE2UsT;:bVk^5g%"X6n@Ji)hA,+9[$0qP`Z!68hoBnPL&>G1c!NI'$0#ueWRg]Ck9`!1EhN(K.Doh
 endstream
 endobj
 318 0 obj
-   91
+   90
 endobj
 89 0 obj
    << 
@@ -1472,7 +1472,7 @@ GapQJ2:XK::bVk^5g%jb6n@Ji)hA,+N6EE/!D$<9`K1HW%i*0>nI:I062V]T6a-Op?e<NO$mG\X!(-a$
 endstream
 endobj
 319 0 obj
-   114
+   113
 endobj
 90 0 obj
    << 
@@ -1485,7 +1485,7 @@ Wj"0G'ehBH4%e,SdK40^+e"8sXu%a2i6EQU~>
 endstream
 endobj
 320 0 obj
-   119
+   118
 endobj
 91 0 obj
    << 
@@ -1510,7 +1510,7 @@ GapQI0[MU0:]M(mb0\34`7$S&YQ3(j#%h8GWOX1.:,1fr;io16KIW)$Kr-5QbK.U-<PT/O9*SH9(BD;a
 endstream
 endobj
 322 0 obj
-   87
+   86
 endobj
 93 0 obj
    << 
@@ -1528,7 +1528,7 @@ T/1B9GP_Kb\&Yl~>
 endstream
 endobj
 323 0 obj
-   508
+   502
 endobj
 94 0 obj
    << 
@@ -1545,7 +1545,7 @@ nAI#rZ\[!jYK@+GgIH<gB>lR(-uUr'\]SK`5;pL7L"4@baD+kLK^[j\fhL!:hUB)i")#0Z:45j#9rrYD
 endstream
 endobj
 324 0 obj
-   472
+   467
 endobj
 95 0 obj
    << 
@@ -1561,7 +1561,7 @@ L`B7IYV3G\Q$f9m<f\uJ+BWHmY8,U)ieA^Vei(@3\(*DWRJ,Es!rIjTl?D6.OV:i&>.jql\K5\1e`dU\
 endstream
 endobj
 325 0 obj
-   353
+   349
 endobj
 96 0 obj
    << 
@@ -1578,7 +1578,7 @@ O*5+T0#?*t6".E>*5H"D#JVEu6$aUGqL@b1r"RSnRUR>1=E:Ad#f&PW#i^T57PKVEUKJdT$1is8k>F.s
 endstream
 endobj
 326 0 obj
-   464
+   459
 endobj
 97 0 obj
    << 
@@ -1595,7 +1595,7 @@ s,(fETB-l'\=>>~>
 endstream
 endobj
 327 0 obj
-   426
+   421
 endobj
 98 0 obj
    << 
@@ -1610,7 +1610,7 @@ h#HKnL@4"@oV&$k"rUhNp.lrOhe%d[hQEC)()4!\!&PeEFPe8K?W4A/fQDVc3m:L#VGB9;_CIad#O;e2
 endstream
 endobj
 328 0 obj
-   250
+   247
 endobj
 99 0 obj
    << 
@@ -1629,7 +1629,7 @@ i**Hu\B-G).9A,WC%Nf/@aQA?HZ!C]Q)(=1*3USg\PNZI&lIM-8(Q\ii`Ino@PN5<kfrfN#SH:bO=A,<
 endstream
 endobj
 329 0 obj
-   575
+   568
 endobj
 100 0 obj
    << 
@@ -1644,7 +1644,7 @@ ClT#L:mu:KW^CSYJolcUoIIb<;jOue)3NJ@]BKU[$=AW?\_ILW*iI+f[j%5`$G">82/=PYaTS^W/Vp,R
 endstream
 endobj
 330 0 obj
-   305
+   302
 endobj
 101 0 obj
    << 
@@ -1657,7 +1657,7 @@ Aul#r`BZdA_1nWS@2a159`Q'"`WZ@Xash`~>
 endstream
 endobj
 331 0 obj
-   118
+   117
 endobj
 102 0 obj
    << 
@@ -1672,7 +1672,7 @@ Gar?,9+Jin#XnEW+r?%=(h;_kWN%T!qep76Nmr4c1(T>a__MSYL@[4E:8VXjW.o"g@q5/)#=3slJ)<Kn
 endstream
 endobj
 332 0 obj
-   253
+   250
 endobj
 103 0 obj
    << 
@@ -1687,7 +1687,7 @@ _=`8oN73;cl_O,1h#%]?GeO.Ur?:V$8al9V!Ies>~>
 endstream
 endobj
 333 0 obj
-   288
+   285
 endobj
 104 0 obj
    << 
@@ -1700,7 +1700,7 @@ GapQFZICZa:bVk^5fsMR0i64S2Za:6(n)<b8Z!>F5m:Ze\Ql'_Ek%bHT^uS1EmRP%iQC(NirT4$;&J0
 endstream
 endobj
 334 0 obj
-   83
+   82
 endobj
 105 0 obj
    << 
@@ -1717,7 +1717,7 @@ E/gXioM<W,If\\:A"H0tEJ44$o-Rh:8,=k<bJ3TMjA<I;~>
 endstream
 endobj
 335 0 obj
-   457
+   452
 endobj
 106 0 obj
    << 
@@ -1732,7 +1732,7 @@ KWb)@-Pt&!YQc+>gKhIg>ejDKe+rZdIBR!BHNQs*hft\!fP(/qS9FKg:ZY3`kpLlZVc7bq~>
 endstream
 endobj
 336 0 obj
-   318
+   315
 endobj
 107 0 obj
    << 
@@ -1748,7 +1748,7 @@ T0a\I0t%[rX[HqY#'\.)qore;X_R`d.cGn'*5XXC5GiG&D@Y4`VSg1k[DeAG3jp)_g8;&F4'_btqPX6*
 endstream
 endobj
 337 0 obj
-   405
+   401
 endobj
 108 0 obj
    << 
@@ -1765,7 +1765,7 @@ eE;QJ:?TTrN?2'5?M>l0+V;\fN0&qNE7k,L2hj</K^6k#LUc@H6Ct+kB`DEU%^iUSLurLl8#eS]B):VV
 endstream
 endobj
 338 0 obj
-   455
+   450
 endobj
 109 0 obj
    << 
@@ -1782,7 +1782,7 @@ d:;:>]\$l&$U?%BN"t.%QM5=On&24nBXXDn1Gi`J34!eGP1h5^0ZKDJ/mnYTIb?27b7F73\`j~>
 endstream
 endobj
 339 0 obj
-   485
+   480
 endobj
 110 0 obj
    << 
@@ -1797,7 +1797,7 @@ ig`CIU2^fOWot^=Zc^@?E8[F6GSC]USdEcLmrScFm&'\)RY74@pcQ)O81J"dGM(>,i)*T5j\@KB7XCqn
 endstream
 endobj
 340 0 obj
-   255
+   252
 endobj
 111 0 obj
    << 
@@ -1815,7 +1815,7 @@ VShTL,3Z9ba:uVMYjEIa`'T_@p,k7gE#:2A@9Zm*h\RnqAa^)RqqSk2jCB?cN]bppmJljnO0@U8p]YWi
 endstream
 endobj
 341 0 obj
-   497
+   491
 endobj
 112 0 obj
    << 
@@ -1830,7 +1830,7 @@ GarVJ8IiW\%(u0=4qNBa0_df5WZKUg?Ya/'Osh,91L?4^'=X3Ibk``(1m,nE87_e5qM'M<d]*4M6Kr"+
 endstream
 endobj
 342 0 obj
-   260
+   257
 endobj
 113 0 obj
    << 
@@ -1845,7 +1845,7 @@ W0>>L+1f$7.2?eM1F:IUqR!iXOEho._/kQj*7?t6L=5e*^5)7KVd/IJIAL9NWH<L~>
 endstream
 endobj
 343 0 obj
-   312
+   309
 endobj
 114 0 obj
    << 
@@ -1859,7 +1859,7 @@ ig;Z<~>
 endstream
 endobj
 344 0 obj
-   171
+   169
 endobj
 115 0 obj
    << 
@@ -1874,7 +1874,7 @@ N=$\9+fU[##-BkbH_".!c-Yi"GdX1;h>RDka).X~>
 endstream
 endobj
 345 0 obj
-   287
+   284
 endobj
 116 0 obj
    << 
@@ -1889,7 +1889,7 @@ oEH#$?2a~>
 endstream
 endobj
 346 0 obj
-   256
+   253
 endobj
 117 0 obj
    << 
@@ -1904,7 +1904,7 @@ Xd3R0mEdHJqqb*:OhU\0h;'dLrS1@AIujKsHZ/\60DG]%8S2E~>
 endstream
 endobj
 347 0 obj
-   297
+   294
 endobj
 118 0 obj
    << 
@@ -1919,7 +1919,7 @@ Gar&:3>04`#jchj59Q!e$0:h?P=_JG^C:8?L`>`cM`@#sFj53Rp)("B>Z,:j?jlR#Hm'2uoqm3l!^3jl
 endstream
 endobj
 348 0 obj
-   257
+   254
 endobj
 119 0 obj
    << 
@@ -1935,7 +1935,7 @@ jKJt\_YjK+n/&a>]86&*A;n^U]_NoJ>n!UNH+#2N2r%KBET-^?">imCId`p";ngEsri_`P~>
 endstream
 endobj
 349 0 obj
-   400
+   396
 endobj
 120 0 obj
    << 
@@ -1963,7 +1963,7 @@ h`.^r@=$#,"6-d?]T#R3D1(5K)P9!uP#LMk!0\pW$F/i#psRo^qd/jG?fe25QToPQQmr~>
 endstream
 endobj
 351 0 obj
-   398
+   394
 endobj
 122 0 obj
    << 
@@ -1979,7 +1979,7 @@ e7#U5-Sp10qc7d)j+1bpJUFn`cL,Z.`V/YsUNXO(@%GVXVFB"?(\PDB%fpcQF:J3ARp>?Y^"Yb[fQ78
 endstream
 endobj
 352 0 obj
-   329
+   325
 endobj
 123 0 obj
    << 
@@ -1993,7 +1993,7 @@ EmIsLCfd%X0>_r)<E$"?F1QPel,-dg7Q+?0?2s>Ad$nA6"nJrsm/~>
 endstream
 endobj
 353 0 obj
-   218
+   216
 endobj
 124 0 obj
    << 
@@ -2006,7 +2006,7 @@ GarW39+HJ+#XnEWU)1&-Hr>;5@pIsj[h`grU>7N^_.5ek8&Tqc<"X6^9-sm08oc'hQRr6u^"ql7!(uYf
 endstream
 endobj
 354 0 obj
-   134
+   133
 endobj
 125 0 obj
    << 
@@ -2019,7 +2019,7 @@ GarW45n8Df$j?$I"Wu*U[RBqP0coia=/f(k-l4cMCj+ROgPQiP*`XJbL1MS56#opJ'U9mEj87Tfmg]u0
 endstream
 endobj
 355 0 obj
-   162
+   161
 endobj
 126 0 obj
    << 
@@ -2032,7 +2032,7 @@ GarWs_%"1&#R/R:;n,(3YZMpEBfsc@Y>p4_&hak]qLT%PNp*\eV5./J7MonZrI9&(:hk9J5<[@4!XdSo
 endstream
 endobj
 356 0 obj
-   133
+   132
 endobj
 127 0 obj
    << 
@@ -2072,7 +2072,7 @@ T::\iW1,-VJYoFFo/%Yn_LT-ll73)FCV7jSlP`@^qH0scQc/hqR+Wl8Jmh)(dhSbQ:O)A&dhDNN!6FpX
 endstream
 endobj
 359 0 obj
-   404
+   400
 endobj
 130 0 obj
    << 
@@ -2085,7 +2085,7 @@ Oi*I#Q,Wt-cd<WK~>
 endstream
 endobj
 360 0 obj
-   99
+   98
 endobj
 131 0 obj
    << 
@@ -2098,7 +2098,7 @@ GapQJ1"8!5:bVk^5g%Rn6n@Ji5X^UUc1JeV9<`Am+d\>%M&qh3>V8BB"0d<<M)gC;iBl"W_e!LqLaiD2
 endstream
 endobj
 361 0 obj
-   112
+   111
 endobj
 132 0 obj
    << 
@@ -2111,7 +2111,7 @@ GapQJ1"8!5:bVk^5g%:R6n@Ji5X^S_bk8bV9<`Am+d\T7MLo(c6W7JX,_6pfQl[IcF,5>i=?##s*%n`I
 endstream
 endobj
 362 0 obj
-   111
+   110
 endobj
 133 0 obj
    << 
@@ -2124,7 +2124,7 @@ GapQI2V0`=:bVk^5g%^l6n@I>RtF.(/4"Y+f>%MWV\jHj'gP0-\^5HZE5D3T#XGcXTUV(]Q,/a*"T["1
 endstream
 endobj
 363 0 obj
-   87
+   86
 endobj
 134 0 obj
    << 
@@ -2147,7 +2147,7 @@ mb0R([BDj0c-k!*`>:=oXM<A:o)G;l~>
 endstream
 endobj
 364 0 obj
-   934
+   923
 endobj
 135 0 obj
    << 
@@ -2160,7 +2160,7 @@ Gar'!5n8Df$j?$I"Wu*-Q\+`l`d#<!?Nl#g>WV,XSQZ:Li/gT$XE9A0/#cr1:f\PcABj$-/S`jR,\_k6
 endstream
 endobj
 365 0 obj
-   122
+   121
 endobj
 136 0 obj
    << 
@@ -2173,7 +2173,7 @@ Gar'!5n:[Q#R'V/Je-KVTXOl79Fpjsf8>E^G[WNMG#hO&LlhJtP)!KpC^-.WPG%)`\g+HM5C#P>R+Z.,
 endstream
 endobj
 366 0 obj
-   123
+   122
 endobj
 137 0 obj
    << 
@@ -2186,7 +2186,7 @@ Gar'a9+&HW$j=q*:>lA@r2b4:,$ijuDef];\oD,F4>k-/kcd971g)l3fEs"fZLF=_d7qEP@2Z^C6L1G`
 endstream
 endobj
 367 0 obj
-   124
+   123
 endobj
 138 0 obj
    << 
@@ -2199,7 +2199,7 @@ GapQI0[MU0:]M(mb0\34`7$S&YQ3(j#%h8GWOX1.:,1fr;io16KIW)$Kr-5QbK.U-<PT/O9*SH9(BD;a
 endstream
 endobj
 368 0 obj
-   87
+   86
 endobj
 139 0 obj
    << 
@@ -2212,7 +2212,7 @@ GapRs0\/$6:bVk^5g%"N6n@Ji)hA,+$r%-rPcfil=Aar!Q_BNZZ:HU7WB!?O<$6r(c%m>lQlu_9<&8R)
 endstream
 endobj
 369 0 obj
-   96
+   95
 endobj
 140 0 obj
    << 
@@ -2225,7 +2225,7 @@ V/ZM9FX.gh~>
 endstream
 endobj
 370 0 obj
-   94
+   93
 endobj
 141 0 obj
    << 
@@ -2240,7 +2240,7 @@ aMkV^^?m^qnYK\FQET/)2(RhO%aej7H#l!jpH$!u/qgN!_(jc$StQ.3g>/?+s+K;!"OI%'?i~>
 endstream
 endobj
 371 0 obj
-   320
+   317
 endobj
 142 0 obj
    << 
@@ -2255,7 +2255,7 @@ Sj@\,"0t)S;aYm+%Ha@Och[^NoG]J)5+kI#;I/E#1sFhW>?olS)>4W*S!mQWE,Wl.)"jD3DJlJ:n)Ce9
 endstream
 endobj
 372 0 obj
-   306
+   303
 endobj
 143 0 obj
    << 
@@ -2270,7 +2270,7 @@ Y$sZ=12R,\HX^<3=(Ed(Xah#$DK6!1I*Rq2QV^nRfOaH*SU(p>5h54sShL$drKLl;:n#D]eb0M=EBs.)
 endstream
 endobj
 373 0 obj
-   282
+   279
 endobj
 144 0 obj
    << 
@@ -2283,7 +2283,7 @@ d^9=A::MMc8*ECXVYn6L2CQumhnP4mc*4T#jUi?-0LRnN&a[qYXWQ2t%9?S=#Hb<m&c~>
 endstream
 endobj
 374 0 obj
-   151
+   150
 endobj
 145 0 obj
    << 
@@ -2300,7 +2300,7 @@ nqD<WQSW._PC<Q7RCDImbFfp4I@9<%1l@<FdFCt.T];d%bm8nr3m2'mU,/$;di?CAMI*I,SG/L8hN.;F
 endstream
 endobj
 375 0 obj
-   416
+   411
 endobj
 146 0 obj
    << 
@@ -2319,7 +2319,7 @@ eog6TIP.DZYacfYHZ)-.4(`er@%VLU?QT97"5ekM^l!;1`:0b(q>Z1M'sB!ShP31s_`g2Hn+Htt9A-r
 endstream
 endobj
 376 0 obj
-   575
+   568
 endobj
 147 0 obj
    << 
@@ -2333,7 +2333,7 @@ T<@YedAaK9SJrhOgI%]J@$,bZFR<8Weh40Y+m!@@/N62OIc(J%Qs9=~>
 endstream
 endobj
 377 0 obj
-   220
+   218
 endobj
 148 0 obj
    << 
@@ -2348,7 +2348,7 @@ Bur6o>dOGS`_EOeNW"I(r09mbe4,Zm`L<[U?f4H9NG,m=$eJMSX^Kjt\Fkn8@rL[.I`i+2mX%V~>
 endstream
 endobj
 378 0 obj
-   322
+   319
 endobj
 149 0 obj
    << 
@@ -2373,7 +2373,7 @@ J86'2Y&L0?BP<#L`kAj?RP9esbU_URgp.PTY!E$^Y1S8Rdbo]j*e[$=TE~>
 endstream
 endobj
 380 0 obj
-   141
+   140
 endobj
 151 0 obj
    << 
@@ -2393,7 +2393,7 @@ mK1^,aBWJHcEKK+md@Od<[nc-,s$;*@9P)n!%T%;`<+l%`_%CUrN^aIk\6><UYU*Tf(?'[PZE8CEm$da
 endstream
 endobj
 381 0 obj
-   720
+   712
 endobj
 152 0 obj
    << 
@@ -2411,7 +2411,7 @@ ZZiUSGrM,(n\Vt$AXTlPS5)CTrF'2?_J#gI0;;Jm5-8TAM`9)ma&/NC::r1W'7(J4gEsGq3=UuQaQVXM
 endstream
 endobj
 382 0 obj
-   548
+   542
 endobj
 153 0 obj
    << 
@@ -2426,7 +2426,7 @@ p]p5,P]bOf:li#a)dt5eK>="\/TsXt'3&/j!bEgsI]n!DCRb7<(\VrnL&~>
 endstream
 endobj
 383 0 obj
-   305
+   302
 endobj
 154 0 obj
    << 
@@ -2443,7 +2443,7 @@ eE?-Y<6#7@3%&l-1c&;u.LaL\lt-<jSXh@oMeE<=[N^!uQKi`A1NliBgtp9eUj#22Xac/m%4"ugM-kag
 endstream
 endobj
 384 0 obj
-   425
+   420
 endobj
 155 0 obj
    << 
@@ -2456,7 +2456,7 @@ Gar?*5n8E!#R'V/_@L<^BPRDd@sYrj?Yq<-XBsQGKHY$K`k67221X31)H(H%dOY#4#A=;Xq7_%tB^!19
 endstream
 endobj
 385 0 obj
-   123
+   122
 endobj
 156 0 obj
    << 
@@ -2472,7 +2472,7 @@ hbIPlCe;8t`cc+k)_D_6HkJk])(JWLK[P<dMZE-E:F93TC4V>,p!>:PV<#G!lL,L>V`pA0Zr[#JlO@og
 endstream
 endobj
 386 0 obj
-   383
+   379
 endobj
 157 0 obj
    << 
@@ -2488,7 +2488,7 @@ r9UL+[(QeY<`()rKL0S`-TT+2)4p=GaD`F:W$6OGf7=mL/B9LrHT7t$SCR)>Jb9rnUC-L*VEq3aEVRZ(
 endstream
 endobj
 387 0 obj
-   329
+   325
 endobj
 158 0 obj
    << 
@@ -2505,7 +2505,7 @@ eE?-Y<6#7@3%&l-1c&;u.LaL\lt-<jSXh@oMeE<=[N^!uQKi`A1NliBgtp9eUj#22Xac/m%4"ugM-kag
 endstream
 endobj
 388 0 obj
-   425
+   420
 endobj
 159 0 obj
    << 
@@ -2519,7 +2519,7 @@ dLoKL;SjV5EQkjcbn_[ffCTU3Phfp'qDdf<RMDg$bC7',]6]Wg^45YR/ml9.)d`";9;-"(~>
 endstream
 endobj
 389 0 obj
-   236
+   234
 endobj
 160 0 obj
    << 
@@ -2532,7 +2532,7 @@ NAZAn@t9i*d#c)/`WZ@mW%"#~>
 endstream
 endobj
 390 0 obj
-   108
+   107
 endobj
 161 0 obj
    << 
@@ -2553,7 +2553,7 @@ Sdp%+b%J?CL.iR]`q28%S#lTQ>gERhP$9Tfld"HOrgI,Oo?[(?V*[."~>
 endstream
 endobj
 391 0 obj
-   795
+   786
 endobj
 162 0 obj
    << 
@@ -2566,7 +2566,7 @@ GapQI0[MU0:]M(mb0\KD`7$TM0EKS@&5(R(_AktA(igK3(aCQPKaU/2jD_qo^^u$2a[%j1LF[ubAeEg#
 endstream
 endobj
 392 0 obj
-   112
+   111
 endobj
 163 0 obj
    << 
@@ -2586,7 +2586,7 @@ rC;'=`P;*US*CMT~>
 endstream
 endobj
 393 0 obj
-   673
+   665
 endobj
 164 0 obj
    << 
@@ -2604,7 +2604,7 @@ F(EGhXDqFsYOW&bGgmK~>
 endstream
 endobj
 394 0 obj
-   513
+   507
 endobj
 165 0 obj
    << 
@@ -2617,7 +2617,7 @@ e[!$@Bg>*LGXh]?'c`RKg!\f/V!Q&Kd;MUF]a$'6n6YihYc.:i()-.U!Aa%#rr~>
 endstream
 endobj
 395 0 obj
-   146
+   145
 endobj
 166 0 obj
    << 
@@ -2630,7 +2630,7 @@ LF\!-N=,_#<$*j~>
 endstream
 endobj
 396 0 obj
-   98
+   97
 endobj
 167 0 obj
    << 
@@ -2649,7 +2649,7 @@ mbuURhZDf[A^E6fAj3OSJ:f#g*d70#rgMt?Ahq"RL(r0>jkb0T5Bo+9rg-tB^'sQ~>
 endstream
 endobj
 397 0 obj
-   640
+   633
 endobj
 168 0 obj
    << 
@@ -2677,7 +2677,7 @@ ECeSjNLf_>(E3p!X1kM+jiMtA8bMHjRNj?=^-6u>Vt_lo3;&hs~>
 endstream
 endobj
 399 0 obj
-   380
+   376
 endobj
 170 0 obj
    << 
@@ -2690,7 +2690,7 @@ GarW39+HIp$jHBqJdZ6!jV.&lN!m;u<f3_Al@p*%RD(Rgh>o17VZdi.]-WM+6_V9N@da#1`hVu*;kUeJ
 endstream
 endobj
 400 0 obj
-   149
+   148
 endobj
 171 0 obj
    << 
@@ -2705,7 +2705,7 @@ bZu^$6%#53m'i,=_1*NtJepQ.",)D=/-~>
 endstream
 endobj
 401 0 obj
-   280
+   277
 endobj
 172 0 obj
    << 
@@ -2722,7 +2722,7 @@ g#tUoURS.Xjo\^(Mitf^q=qoMmCReS?W?d&U]~>
 endstream
 endobj
 402 0 obj
-   449
+   444
 endobj
 173 0 obj
    << 
@@ -2735,7 +2735,7 @@ GapQI0[MU0:]M(mb0\Q>`7$S&YQ3(jk%8#(WOX1.:,1g]M*Mg:EZ(9K+=kRmJf+S*0LF<QK5O-g<sD_E
 endstream
 endobj
 403 0 obj
-   92
+   91
 endobj
 174 0 obj
    << 
@@ -2750,7 +2750,7 @@ HN~>
 endstream
 endobj
 404 0 obj
-   250
+   247
 endobj
 175 0 obj
    << 
@@ -2764,7 +2764,7 @@ ed'juq[Bf]X`S<"$g)pY+JF#XcbRM;_<Lapi<.s+JhLP0:=0~>
 endstream
 endobj
 405 0 obj
-   214
+   212
 endobj
 176 0 obj
    << 
@@ -2777,7 +2777,7 @@ GapQF1Y4E::bVk^5fs.%/*IljJ/AWJ(19^>6VCo#SRTYD'7hXSj[)n/_Z_gt6NF,4#Mk=YXphHi/c`j\
 endstream
 endobj
 406 0 obj
-   87
+   86
 endobj
 177 0 obj
    << 
@@ -2792,7 +2792,7 @@ oK`325h6/23Hlj1]+G0?3a/5h9&"dG_VK1Oh/#ZbpND#0hDZSO)gVFrRAYG!YOW&>8p,4~>
 endstream
 endobj
 407 0 obj
-   317
+   314
 endobj
 178 0 obj
    << 
@@ -2805,7 +2805,7 @@ e^OXM?taG:CeG8L[5hJ0>\RFCg;>..~>
 endstream
 endobj
 408 0 obj
-   114
+   113
 endobj
 179 0 obj
    << 
@@ -2822,7 +2822,7 @@ $:p6M!!'BdXL>F.`j+/NdR>ZSGOVn$/(X5!"Y%l<+PsQ-HP>kRffMc=hq`^$TZ>WlkP@45X*gBOS?kp?
 endstream
 endobj
 409 0 obj
-   436
+   431
 endobj
 180 0 obj
    << 
@@ -2835,7 +2835,7 @@ VZ?js$#m!?OU><u!#Dac5>-\<6:@`i1s9fMI<Js@Ah=LU24uLHo!<H.#nJRL2Yd~>
 endstream
 endobj
 410 0 obj
-   147
+   146
 endobj
 181 0 obj
    << 
@@ -2850,7 +2850,7 @@ GarW55n_'X#Y"KZ+r?%;U7g[`Vpg@5s0eZS>+85'T(;oJA.B[=JG*\G["78u;Ntc;/MuZ3?(gEY3K)J?
 endstream
 endobj
 411 0 obj
-   271
+   268
 endobj
 182 0 obj
    << 
@@ -2866,7 +2866,7 @@ i[4J]Dl7ubli*,uq,31\~>
 endstream
 endobj
 412 0 obj
-   350
+   346
 endobj
 183 0 obj
    << 
@@ -2885,7 +2885,7 @@ Z`=R[28P/&26T60\d7".ruD%=]o<.h~>
 endstream
 endobj
 413 0 obj
-   606
+   599
 endobj
 184 0 obj
    << 
@@ -2901,7 +2901,7 @@ AX\?;Wg&_$Fi<D@H>mNo[V(dCVd/olPGgEU4'UbF7($9L2(k*kC-VF%OjF~>
 endstream
 endobj
 414 0 obj
-   388
+   384
 endobj
 185 0 obj
    << 
@@ -2915,7 +2915,7 @@ K%aqL?L#MM1YU["m=BT'lQ:2UB?%IgA"FQd'E89i6>=&$Q[Q[d[a.r$~>
 endstream
 endobj
 415 0 obj
-   221
+   219
 endobj
 186 0 obj
    << 
@@ -2929,7 +2929,7 @@ Gar&99+o,b#i0P/044uP^mq<j:)E'lgI>j;d>c5"pJGe?+XXj^X%8K1e5<XI(`ih8p&S]()tel0UOsE.
 endstream
 endobj
 416 0 obj
-   221
+   219
 endobj
 187 0 obj
    << 
@@ -2943,7 +2943,7 @@ $>QK8Ec',dT$[K0gMWs:A/siVg=tWjmTUQ)+Hro-B5n:'D^ETm"BF5*X)*"NJhN;)?D7~>
 endstream
 endobj
 417 0 obj
-   234
+   232
 endobj
 188 0 obj
    << 
@@ -2959,7 +2959,7 @@ F,;f;aA6HLgGha7$l>GqA[qkQQ'W%N,RO(RkJEmh-OZf-$,\S\<`X!Eg695@X9iqfVT$Y_dp^Td0HW`u
 endstream
 endobj
 418 0 obj
-   408
+   404
 endobj
 189 0 obj
    << 
@@ -2973,7 +2973,7 @@ A&Yj2h?T9_X:A5h!B.g)bW`-Zl^jf]\'*2;+YepX<6!WcEgjL+;'-W0&p_VZ>3U)r,8=A:mN7J;fYQ>b
 endstream
 endobj
 419 0 obj
-   240
+   238
 endobj
 190 0 obj
    << 
@@ -2991,7 +2991,7 @@ L&nglO9fpa9j7cJ4KmbuCQoLXS=>N0h?0@u&^l;;';"Ka5/"(=Hf#9O(Md2e?k7FWOmK&baVk!Jp<<3#
 endstream
 endobj
 420 0 obj
-   507
+   501
 endobj
 191 0 obj
    << 
@@ -3005,7 +3005,7 @@ Garo<5n:gU#Y"KZU)1$7$B"SG1p_/h^TECX'IU4!H2)mY(SDdVK6FVbXMg?DVonKG^+^u"rg81Q+PNYr
 endstream
 endobj
 421 0 obj
-   186
+   184
 endobj
 192 0 obj
    << 
@@ -3024,7 +3024,7 @@ oe'fIL&A0+Q_go+gg\O!s1_Fgp8e..If\illEp~>
 endstream
 endobj
 422 0 obj
-   614
+   607
 endobj
 193 0 obj
    << 
@@ -3038,7 +3038,7 @@ Garo;5nX8C#R'V/_@N#3&1%9IV/fuDJ'El=<gG!I7pBS_@I1I$;V@+:</.9O6A%2TO3^=M`]fq^>dkBN
 endstream
 endobj
 423 0 obj
-   166
+   164
 endobj
 194 0 obj
    << 
@@ -3051,7 +3051,7 @@ e`d2<LM).MG*&r@!7/YoJVmWWYo=NS"i_+#T>ec%&NBd.#jp[<\4B[D&D(eL3'lVT?ntpP%U\=16]D~>
 endstream
 endobj
 424 0 obj
-   162
+   161
 endobj
 195 0 obj
    << 
@@ -3065,7 +3065,7 @@ R57fu)ZKoj7gHom#,"#8#:='I_1'0j>%&-8q\?d?-5GB&N;HTR!2_`.QF):]"0e"):q;1;qLl.\6pbNh
 endstream
 endobj
 425 0 obj
-   179
+   177
 endobj
 196 0 obj
    << 
@@ -3079,7 +3079,7 @@ A9.qY'YFYrY7?rb",Pqf*gi=k%s@t`;M@udhiGV(2c9>OUTCBagB<d3([B2TJmhNKd:-&6s4@Ft'I:6p
 endstream
 endobj
 426 0 obj
-   181
+   179
 endobj
 197 0 obj
    << 
@@ -3092,7 +3092,7 @@ L73Ysb`.UURLIG<"je9YK5Lt9gb^V`,5NbZ~>
 endstream
 endobj
 427 0 obj
-   119
+   118
 endobj
 198 0 obj
    << 
@@ -3105,7 +3105,7 @@ Gar'!5n:[Q#R'V/_@L<V'>XW)9b7%!CScU#H=:5iQR5fGPEdGhS#.`I9ko<hj]/"3(s#*]3Wo/2Jd7fe
 endstream
 endobj
 428 0 obj
-   124
+   123
 endobj
 199 0 obj
    << 
@@ -3118,7 +3118,7 @@ D[,&3(iJQuf;0,6r;mhU*Ng[j\:KaJ>!c:U7766kI;ORQX^#n_$Q=dV=9~>
 endstream
 endobj
 429 0 obj
-   141
+   140
 endobj
 200 0 obj
    << 
@@ -3131,7 +3131,7 @@ VHYb2]hh3dK`c.K%rE=XAh+2e"09r!TirXcCE7MTDu0Rk1,r7F_[4Ji3[X~>
 endstream
 endobj
 430 0 obj
-   142
+   141
 endobj
 201 0 obj
    << 
@@ -3148,7 +3148,7 @@ GNXR.K_d$!ofT:98YB!N]#@Wa$["2qhNc4SggUH;e^<A,C+[pY.pm^-\1\\R1[+9,q&IJGd9$/FFFpAY
 endstream
 endobj
 431 0 obj
-   412
+   407
 endobj
 202 0 obj
    << 
@@ -3165,7 +3165,7 @@ Siuo&6G>'[g%W*clRR@L?V+)!7f~>
 endstream
 endobj
 432 0 obj
-   439
+   434
 endobj
 203 0 obj
    << 
@@ -3182,7 +3182,7 @@ W+B,7RC97?]#Q9;CHLjKq/&Ip"C@(7*L"kPBT^#[&!!"*I^_NMfrX$~>
 endstream
 endobj
 433 0 obj
-   466
+   461
 endobj
 204 0 obj
    << 
@@ -3199,7 +3199,7 @@ C>"ngVQK0Nm^\3i[!rtn-"&'-FiDZr9>)-lplY.FY4;.i5OBNu^oYZ~>
 endstream
 endobj
 434 0 obj
-   466
+   461
 endobj
 205 0 obj
    << 
@@ -3216,7 +3216,7 @@ W+B29RC97?]&tQA[^1E#s!:M1^q0mf@'fnLHid9:olJRco_FG2P`M&AgUB!7DLZ\=[Xn~>
 endstream
 endobj
 435 0 obj
-   480
+   475
 endobj
 206 0 obj
    << 
@@ -3235,7 +3235,7 @@ MKDNdeNDC(&&%!/6AblAkTc,:Hg<tc.]<X.cCq8WIDh*.X^;*MY3l6HpUpo`Y(+6Drc\~>
 endstream
 endobj
 436 0 obj
-   644
+   637
 endobj
 207 0 obj
    << 
@@ -3252,7 +3252,7 @@ VLFn][6NON(Y#;T5[@^t/;N$U*^1f6>t@e=!:/kpO5'h.Y<@D*gId<g^'UGX&D^pKLknmf!0&HuTk#72
 endstream
 endobj
 437 0 obj
-   485
+   480
 endobj
 208 0 obj
    << 
@@ -3265,7 +3265,7 @@ Gar&8aUNbC&H$G]1a$3;Y'u?"Jc1(076pc)am<8WNn-5Nl;Jk#U=hXVAL0IZ%>>L?"N&0_W5Dle*Kl!e
 endstream
 endobj
 438 0 obj
-   147
+   146
 endobj
 209 0 obj
    << 
@@ -3282,7 +3282,7 @@ D+`M(%phu^9RpaV3!,1%$II=G)DKNTof*iRkn8]`g'o1MLb!\Rf>*e<[#7?h`/%J.UThi!X':F5-^[&I
 endstream
 endobj
 439 0 obj
-   481
+   476
 endobj
 210 0 obj
    << 
@@ -3297,7 +3297,7 @@ o"KA$@lE:-jL)YN^-C(p4RH:#$>4tg)d\6IFD$UTNb,p2*02W5VhWBDQX?\'Foh~>
 endstream
 endobj
 440 0 obj
-   311
+   308
 endobj
 211 0 obj
    << 
@@ -3312,7 +3312,7 @@ L`V^f[9m<13sutXIfZ<-!V$SL2Y%%V&V?[PP`ZX#DsD]lD,):-oX>Rdmd_bm0NYT2k]5"gb2AMqg`*%N
 endstream
 endobj
 441 0 obj
-   312
+   309
 endobj
 212 0 obj
    << 
@@ -3328,7 +3328,7 @@ dH+m.cuM&'B?F_0UV*_s5+_Hthh@t\q)>qoGC>(d<>%-[5_rIV2-h,8!c!.c^g97.XDMI1YOVc>Mgqo
 endstream
 endobj
 442 0 obj
-   329
+   325
 endobj
 213 0 obj
    << 
@@ -3344,7 +3344,7 @@ lf6u5c*R4=?;g3Xf?;eCFH<?Ub?m8UN5+=oJlOXCA8M)I`g6Sf#VEH-f,ikW&D22G=rr^Nrg#L6.#,)
 endstream
 endobj
 443 0 obj
-   329
+   325
 endobj
 214 0 obj
    << 
@@ -3358,7 +3358,7 @@ GarW49+Ji^$q0hR74o,S*b4+jXf="prO2ss84h;?(=/TB8%F<j[lBrkZA#tA-<6@)nt!k<Y$,F"#\nnU
 endstream
 endobj
 444 0 obj
-   208
+   206
 endobj
 215 0 obj
    << 
@@ -3374,7 +3374,7 @@ m/sh5L`-~>
 endstream
 endobj
 445 0 obj
-   338
+   334
 endobj
 216 0 obj
    << 
@@ -3392,7 +3392,7 @@ qt)A^d9IVoeQJq6WTS9pe7?B3,cUD[=@+R^9\:Rb1Bu3><i_0.Q?7hJOggOF?@Ct>BknO+l=dY2ol?cM
 endstream
 endobj
 446 0 obj
-   539
+   533
 endobj
 217 0 obj
    << 
@@ -3410,7 +3410,7 @@ cq8/)S-cMgp#H)2]CBgVhZt.2`Zu+#rr!E#2s%CEC]=ED?J$t~>
 endstream
 endobj
 447 0 obj
-   543
+   537
 endobj
 218 0 obj
    << 
@@ -3428,7 +3428,7 @@ BVr4fc@f>X2;J3BhqeqDpHa%4(&USCHckZ(NL-"14FR9=aOi3~>
 endstream
 endobj
 448 0 obj
-   543
+   537
 endobj
 219 0 obj
    << 
@@ -3446,7 +3446,7 @@ gog(EOl8<A3D*MUFIs]P8u6mWX2BXCUoeIf`1i?$rM"7f,m@1NGo?@1E:V[XDiA=P`.Z,5]>A@>U%dfR
 endstream
 endobj
 449 0 obj
-   561
+   555
 endobj
 220 0 obj
    << 
@@ -3466,7 +3466,7 @@ r@iU*r_+Ynp&Fjm/m0$%~>
 endstream
 endobj
 450 0 obj
-   678
+   670
 endobj
 221 0 obj
    << 
@@ -3484,7 +3484,7 @@ B8%^!;K>L7OEB$^#g1"Tch*7E4h92'mBE$!q.iCTmYMD7L@2/GU;R6()c+$X,!!Hn(td3<\/R#R[mf4<
 endstream
 endobj
 451 0 obj
-   561
+   555
 endobj
 222 0 obj
    << 
@@ -3506,7 +3506,7 @@ N`"`r<3*]D<sKK*AmfZommsNP.Z\5_$SlV%01H^&X3H4m2YSUPJ?t;mc=3Gp/Rl&g/M>F)\;qP^NQ3GT
 endstream
 endobj
 452 0 obj
-   821
+   811
 endobj
 223 0 obj
    << 
@@ -3527,7 +3527,7 @@ Um-D++Eu%1I84oN#ZHkD(b\IO<ppQtHdoM)LP^-&6#*HH<0oAHb0L=07<'d3ELj-k]I`nAbj9L;bX0so
 endstream
 endobj
 453 0 obj
-   774
+   765
 endobj
 224 0 obj
    << 
@@ -3546,7 +3546,7 @@ quK\a]\3J$rr%W/jf<cp+3qdbV#~>
 endstream
 endobj
 454 0 obj
-   603
+   596
 endobj
 225 0 obj
    << 
@@ -3563,7 +3563,7 @@ AG84FD_g5e9>(7m:Z66-psl=j7fFa9ndWtG-a3)FrW$cuXLn~>
 endstream
 endobj
 455 0 obj
-   460
+   455
 endobj
 226 0 obj
    << 
@@ -3580,7 +3580,7 @@ mO>4"$@dpfI>hT*r\^^Zob`MG?\,IrDh($DSDP<adf,OKC_Nn\~>
 endstream
 endobj
 456 0 obj
-   462
+   457
 endobj
 227 0 obj
    << 
@@ -3597,7 +3597,7 @@ VsL!*r$fYXECeotjBk4.T>4T+EfgSQ&<lq9!$&0ikc8b&MWtet:Z0ds<$pMa&'VMk@/~>
 endstream
 endobj
 457 0 obj
-   479
+   474
 endobj
 228 0 obj
    << 
@@ -3614,7 +3614,7 @@ U2LK8Hiijkdb48V#pU>;"ql8?D*BZHfG\5V.L+KPO.tb&bD:$"M`$;VpUReHAjTStd/>D9-o\c4g2Le2
 endstream
 endobj
 458 0 obj
-   479
+   474
 endobj
 229 0 obj
    << 
@@ -3627,7 +3627,7 @@ GapQFZICZa:bVk^5YBYT9Fjgd)d%WD%F#<DA5`oITE;\O(1;!i>c9,m\BMc?$pI?P%_;s,>T$f1[cVU5
 endstream
 endobj
 459 0 obj
-   124
+   123
 endobj
 230 0 obj
    << 
@@ -3640,7 +3640,7 @@ mk^Uu6(u0j17oIA;%lj)IT(9bquR2.&`"=bIGb4XYplO~>
 endstream
 endobj
 460 0 obj
-   128
+   127
 endobj
 231 0 obj
    << 
@@ -3653,7 +3653,7 @@ Gar'#3tf=O#Xj#7i<=1b7*tgA1+CHGgF.Njf]_m:(F2W(3TJ7Z0(^V%MMi3JT]Pk;i43TTB2mVI5jue0
 endstream
 endobj
 461 0 obj
-   147
+   146
 endobj
 232 0 obj
    << 
@@ -3666,7 +3666,7 @@ Garo:b7T7I$jH+!Jd-0b6pCQ/Nec!]<Pn6&e-gh%h@cQm(o'bgE^>qiZjTn_Oh3Jp"EZDlZje=H)Q4;X
 endstream
 endobj
 462 0 obj
-   142
+   141
 endobj
 233 0 obj
    << 
@@ -3686,7 +3686,7 @@ jO]Xo#=o*j/76;2ob_m;\Q"ub)d?c6.FMsLS3gA<Br3hfm`)E3,W"#sZ[1M6)A1YlkT@Hm'YhXpLkb^q
 endstream
 endobj
 463 0 obj
-   658
+   650
 endobj
 234 0 obj
    << 
@@ -3704,7 +3704,7 @@ $C59^%JO8N\ZFrZo+&f_oe#Sn`U+Ra1T-b?[W\:tBipX#1L5<!72_Bd*8Jt9.mEtaZ^C.?AT!"!n+$jX
 endstream
 endobj
 464 0 obj
-   498
+   492
 endobj
 235 0 obj
    << 
@@ -3721,7 +3721,7 @@ Q\c_S;bl]`bq+>!Zf4,P!1q_hR;Uh,7@L[3I_olU/n0gqd.?A(.fsrUP@Bb/kBr'[l0HfB*sMA6lBebQ
 endstream
 endobj
 465 0 obj
-   442
+   437
 endobj
 236 0 obj
    << 
@@ -3738,7 +3738,7 @@ Q\dYaTq'sI>$1^TB>o5,!'Jg11#8^"RP\sArIicA\qi67Kq9ZQ[j$?(1205B9$Z<*5BD88mT1Qpg!hZb
 endstream
 endobj
 466 0 obj
-   445
+   440
 endobj
 237 0 obj
    << 
@@ -3755,7 +3755,7 @@ hBmCk9f]Tt1pcsscAM@2!I/e^A\(U&'PZ8fq['GH\qi4a6dM7BXpEtI9Su]YSF[c\VlrnRr@(,kYG53l
 endstream
 endobj
 467 0 obj
-   461
+   456
 endobj
 238 0 obj
    << 
@@ -3774,7 +3774,7 @@ hsCrH8*l!~>
 endstream
 endobj
 468 0 obj
-   585
+   578
 endobj
 239 0 obj
    << 
@@ -3791,7 +3791,7 @@ AR::n_^1oY)uWQCbO]$"WNnPC:Nd@DKk&e"M5Bd?@C"eP([YD>2?~>
 endstream
 endobj
 469 0 obj
-   464
+   459
 endobj
 240 0 obj
    << 
@@ -3804,7 +3804,7 @@ ZZC_)iP1!gK6(_7Iu>)G*Uj+uUGOJ+=;B5pI\^W^&FHu(/-f:B$kI`<brV<~>
 endstream
 endobj
 470 0 obj
-   143
+   142
 endobj
 241 0 obj
    << 
@@ -3821,7 +3821,7 @@ H78P?*#l4lm$I"lI5MFlk%#".O\j9[Nt`6C`Vo'3]4">sr;@4\rJ7E-I*2hFR$mrfb:eiJ\F'~>
 endstream
 endobj
 471 0 obj
-   485
+   480
 endobj
 242 0 obj
    << 
@@ -3837,7 +3837,7 @@ Zffs(W'bYmi\Aa_MjU8(!N"k\"=`.5D!!+<<"B:hh&*0ZS*K_5i6ud?h7o;W":Wfa0CW7lq'7q!;k'8^
 endstream
 endobj
 472 0 obj
-   348
+   344
 endobj
 243 0 obj
    << 
@@ -3853,7 +3853,7 @@ a4Hf2"s34tJfkc3KO>D>,re]4&d*"']&VSI;M$$*`VM>Z565\WOEYdmOLASJ)Qd+tk\(m0%AR73nWUdG
 endstream
 endobj
 473 0 obj
-   347
+   343
 endobj
 244 0 obj
    << 
@@ -3869,7 +3869,7 @@ C^0s4*C00M6<^f6CG,nh'DP\q9"r_,bqtHV~>
 endstream
 endobj
 474 0 obj
-   365
+   361
 endobj
 245 0 obj
    << 
@@ -3885,7 +3885,7 @@ VF6tMg$..nFq-qMMi%g79&C7r8YrmWR_dQr79_m$]&PR>OY/(>e+LG6a.IC,^Q=T,noMJsU\'C[@AMe?
 endstream
 endobj
 475 0 obj
-   365
+   361
 endobj
 246 0 obj
    << 
@@ -3901,7 +3901,7 @@ oD~>
 endstream
 endobj
 476 0 obj
-   332
+   328
 endobj
 247 0 obj
    << 
@@ -3918,7 +3918,7 @@ h``^YP<GX>fnjeA1UX,E!_./C+(gN8V'epmeK#`WL@nb9s(<-Cq5_)_<,\4,=3D7/qX%B0iq>G]?`oL+
 endstream
 endobj
 477 0 obj
-   445
+   440
 endobj
 248 0 obj
    << 
@@ -3934,7 +3934,7 @@ c_K)9g6HI]>I<g7bsZ.]3NVNtjV4%Tp2cV^9`&"5N@R<Vnc9kp!AJ6g3#s-NU9<<-XO2/4nnOfE!SQs)
 endstream
 endobj
 478 0 obj
-   349
+   345
 endobj
 249 0 obj
    << 
@@ -3947,7 +3947,7 @@ cA/IHi(DJX!WXrt-Y3~>
 endstream
 endobj
 479 0 obj
-   102
+   101
 endobj
 17 0 obj
    << 
@@ -4020,489 +4020,489 @@ xref
 0000000000 65535 f 
 0000000015 00000 n 
 0000000315 00000 n 
-0000118845 00000 n 
+0000118027 00000 n 
 0000000445 00000 n 
 0000000521 00000 n 
 0000000609 00000 n 
-0000003380 00000 n 
-0000003403 00000 n 
-0000003688 00000 n 
-0000003709 00000 n 
-0000005608 00000 n 
-0000005632 00000 n 
-0000005919 00000 n 
-0000005941 00000 n 
-0000007840 00000 n 
-0000007864 00000 n 
-0000116705 00000 n 
-0000013232 00000 n 
-0000008231 00000 n 
-0000014817 00000 n 
-0000015207 00000 n 
-0000015461 00000 n 
-0000015714 00000 n 
-0000015937 00000 n 
-0000016191 00000 n 
-0000016567 00000 n 
-0000017089 00000 n 
-0000017476 00000 n 
-0000017651 00000 n 
-0000017907 00000 n 
-0000018167 00000 n 
-0000018544 00000 n 
-0000019253 00000 n 
-0000020072 00000 n 
-0000020855 00000 n 
-0000021087 00000 n 
-0000021420 00000 n 
-0000021756 00000 n 
-0000022068 00000 n 
-0000022334 00000 n 
-0000022561 00000 n 
-0000022777 00000 n 
-0000022990 00000 n 
-0000023223 00000 n 
-0000023827 00000 n 
-0000024134 00000 n 
-0000024620 00000 n 
-0000025290 00000 n 
-0000025618 00000 n 
-0000026148 00000 n 
-0000026841 00000 n 
-0000027154 00000 n 
-0000027949 00000 n 
-0000028587 00000 n 
-0000028833 00000 n 
-0000029098 00000 n 
-0000029354 00000 n 
-0000029605 00000 n 
-0000029861 00000 n 
-0000030373 00000 n 
-0000031352 00000 n 
-0000031679 00000 n 
-0000032280 00000 n 
-0000032767 00000 n 
-0000033283 00000 n 
-0000033549 00000 n 
-0000033802 00000 n 
-0000034301 00000 n 
-0000034561 00000 n 
-0000034777 00000 n 
-0000035166 00000 n 
-0000035526 00000 n 
-0000035759 00000 n 
-0000036325 00000 n 
-0000036686 00000 n 
-0000037253 00000 n 
-0000037723 00000 n 
-0000038311 00000 n 
-0000038831 00000 n 
-0000039489 00000 n 
-0000039732 00000 n 
-0000040147 00000 n 
-0000040445 00000 n 
-0000040869 00000 n 
-0000041150 00000 n 
-0000041461 00000 n 
-0000041871 00000 n 
-0000042116 00000 n 
-0000042343 00000 n 
-0000042594 00000 n 
-0000042850 00000 n 
-0000043057 00000 n 
-0000043280 00000 n 
-0000043925 00000 n 
-0000044534 00000 n 
-0000045024 00000 n 
-0000045625 00000 n 
-0000046188 00000 n 
-0000046575 00000 n 
-0000047287 00000 n 
-0000047730 00000 n 
-0000047986 00000 n 
-0000048377 00000 n 
-0000048803 00000 n 
-0000049023 00000 n 
-0000049618 00000 n 
-0000050074 00000 n 
-0000050617 00000 n 
-0000051210 00000 n 
-0000051833 00000 n 
-0000052226 00000 n 
-0000052861 00000 n 
-0000053259 00000 n 
-0000053709 00000 n 
-0000054018 00000 n 
-0000054443 00000 n 
-0000054837 00000 n 
-0000055272 00000 n 
-0000055667 00000 n 
-0000056205 00000 n 
-0000056421 00000 n 
-0000056957 00000 n 
-0000057424 00000 n 
-0000057780 00000 n 
-0000058052 00000 n 
-0000058352 00000 n 
-0000058623 00000 n 
-0000058840 00000 n 
-0000059057 00000 n 
-0000059599 00000 n 
-0000059835 00000 n 
-0000060085 00000 n 
-0000060334 00000 n 
-0000060558 00000 n 
-0000061630 00000 n 
-0000061890 00000 n 
-0000062151 00000 n 
-0000062413 00000 n 
-0000062637 00000 n 
-0000062870 00000 n 
-0000063101 00000 n 
-0000063559 00000 n 
-0000064003 00000 n 
-0000064423 00000 n 
-0000064712 00000 n 
-0000065266 00000 n 
-0000065979 00000 n 
-0000066337 00000 n 
-0000066797 00000 n 
-0000067014 00000 n 
-0000067293 00000 n 
-0000068151 00000 n 
-0000068837 00000 n 
-0000069280 00000 n 
-0000069843 00000 n 
-0000070104 00000 n 
-0000070625 00000 n 
-0000071092 00000 n 
-0000071655 00000 n 
-0000072029 00000 n 
-0000072275 00000 n 
-0000073208 00000 n 
-0000073458 00000 n 
-0000074269 00000 n 
-0000074920 00000 n 
-0000075204 00000 n 
-0000075439 00000 n 
-0000076217 00000 n 
-0000076429 00000 n 
-0000076947 00000 n 
-0000077234 00000 n 
-0000077652 00000 n 
-0000078239 00000 n 
-0000078468 00000 n 
-0000078856 00000 n 
-0000079208 00000 n 
-0000079432 00000 n 
-0000079887 00000 n 
-0000080139 00000 n 
-0000080713 00000 n 
-0000080998 00000 n 
-0000081407 00000 n 
-0000081895 00000 n 
-0000082639 00000 n 
-0000083165 00000 n 
-0000083524 00000 n 
-0000083883 00000 n 
-0000084255 00000 n 
-0000084801 00000 n 
-0000085179 00000 n 
-0000085824 00000 n 
-0000086148 00000 n 
-0000086900 00000 n 
-0000087204 00000 n 
-0000087504 00000 n 
-0000087821 00000 n 
-0000088140 00000 n 
-0000088397 00000 n 
-0000088659 00000 n 
-0000088938 00000 n 
-0000089218 00000 n 
-0000089768 00000 n 
-0000090345 00000 n 
-0000090949 00000 n 
-0000091553 00000 n 
-0000092171 00000 n 
-0000092953 00000 n 
-0000093576 00000 n 
-0000093861 00000 n 
-0000094480 00000 n 
-0000094929 00000 n 
-0000095379 00000 n 
-0000095846 00000 n 
-0000096313 00000 n 
-0000096659 00000 n 
-0000097135 00000 n 
-0000097812 00000 n 
-0000098493 00000 n 
-0000099174 00000 n 
-0000099873 00000 n 
-0000100689 00000 n 
-0000101388 00000 n 
-0000102347 00000 n 
+0000003348 00000 n 
+0000003371 00000 n 
+0000003656 00000 n 
+0000003677 00000 n 
+0000005556 00000 n 
+0000005580 00000 n 
+0000005867 00000 n 
+0000005889 00000 n 
+0000007768 00000 n 
+0000007792 00000 n 
+0000115887 00000 n 
+0000013160 00000 n 
+0000008159 00000 n 
+0000014745 00000 n 
+0000015132 00000 n 
+0000015385 00000 n 
+0000015637 00000 n 
+0000015859 00000 n 
+0000016112 00000 n 
+0000016486 00000 n 
+0000017004 00000 n 
+0000017388 00000 n 
+0000017563 00000 n 
+0000017818 00000 n 
+0000018077 00000 n 
+0000018452 00000 n 
+0000019155 00000 n 
+0000019966 00000 n 
+0000020742 00000 n 
+0000020973 00000 n 
+0000021304 00000 n 
+0000021638 00000 n 
+0000021948 00000 n 
+0000022213 00000 n 
+0000022439 00000 n 
+0000022655 00000 n 
+0000022868 00000 n 
+0000023100 00000 n 
+0000023699 00000 n 
+0000024004 00000 n 
+0000024486 00000 n 
+0000025150 00000 n 
+0000025476 00000 n 
+0000026002 00000 n 
+0000026689 00000 n 
+0000027000 00000 n 
+0000027787 00000 n 
+0000028419 00000 n 
+0000028664 00000 n 
+0000028928 00000 n 
+0000029183 00000 n 
+0000029433 00000 n 
+0000029688 00000 n 
+0000030196 00000 n 
+0000031165 00000 n 
+0000031490 00000 n 
+0000032086 00000 n 
+0000032569 00000 n 
+0000033081 00000 n 
+0000033346 00000 n 
+0000033598 00000 n 
+0000034093 00000 n 
+0000034352 00000 n 
+0000034568 00000 n 
+0000034954 00000 n 
+0000035312 00000 n 
+0000035544 00000 n 
+0000036105 00000 n 
+0000036464 00000 n 
+0000037026 00000 n 
+0000037492 00000 n 
+0000038075 00000 n 
+0000038591 00000 n 
+0000039243 00000 n 
+0000039485 00000 n 
+0000039897 00000 n 
+0000040194 00000 n 
+0000040615 00000 n 
+0000040895 00000 n 
+0000041204 00000 n 
+0000041611 00000 n 
+0000041855 00000 n 
+0000042081 00000 n 
+0000042331 00000 n 
+0000042586 00000 n 
+0000042793 00000 n 
+0000043015 00000 n 
+0000043654 00000 n 
+0000044258 00000 n 
+0000044744 00000 n 
+0000045340 00000 n 
+0000045898 00000 n 
+0000046282 00000 n 
+0000046987 00000 n 
+0000047427 00000 n 
+0000047682 00000 n 
+0000048070 00000 n 
+0000048493 00000 n 
+0000048712 00000 n 
+0000049302 00000 n 
+0000049755 00000 n 
+0000050294 00000 n 
+0000050882 00000 n 
+0000051500 00000 n 
+0000051890 00000 n 
+0000052519 00000 n 
+0000052914 00000 n 
+0000053361 00000 n 
+0000053668 00000 n 
+0000054090 00000 n 
+0000054481 00000 n 
+0000054913 00000 n 
+0000055305 00000 n 
+0000055839 00000 n 
+0000056055 00000 n 
+0000056587 00000 n 
+0000057050 00000 n 
+0000057404 00000 n 
+0000057675 00000 n 
+0000057974 00000 n 
+0000058244 00000 n 
+0000058461 00000 n 
+0000058678 00000 n 
+0000059216 00000 n 
+0000059451 00000 n 
+0000059700 00000 n 
+0000059948 00000 n 
+0000060171 00000 n 
+0000061232 00000 n 
+0000061491 00000 n 
+0000061751 00000 n 
+0000062012 00000 n 
+0000062235 00000 n 
+0000062467 00000 n 
+0000062697 00000 n 
+0000063152 00000 n 
+0000063593 00000 n 
+0000064010 00000 n 
+0000064298 00000 n 
+0000064847 00000 n 
+0000065553 00000 n 
+0000065909 00000 n 
+0000066366 00000 n 
+0000066583 00000 n 
+0000066861 00000 n 
+0000067711 00000 n 
+0000068391 00000 n 
+0000068831 00000 n 
+0000069389 00000 n 
+0000069649 00000 n 
+0000070166 00000 n 
+0000070629 00000 n 
+0000071187 00000 n 
+0000071559 00000 n 
+0000071804 00000 n 
+0000072728 00000 n 
+0000072977 00000 n 
+0000073780 00000 n 
+0000074425 00000 n 
+0000074708 00000 n 
+0000074942 00000 n 
+0000075713 00000 n 
+0000075925 00000 n 
+0000076439 00000 n 
+0000076725 00000 n 
+0000077140 00000 n 
+0000077722 00000 n 
+0000077950 00000 n 
+0000078335 00000 n 
+0000078685 00000 n 
+0000078908 00000 n 
+0000079360 00000 n 
+0000079611 00000 n 
+0000080180 00000 n 
+0000080464 00000 n 
+0000080870 00000 n 
+0000081354 00000 n 
+0000082091 00000 n 
+0000082613 00000 n 
+0000082970 00000 n 
+0000083327 00000 n 
+0000083697 00000 n 
+0000084239 00000 n 
+0000084615 00000 n 
+0000085254 00000 n 
+0000085576 00000 n 
+0000086321 00000 n 
+0000086623 00000 n 
+0000086922 00000 n 
+0000087237 00000 n 
+0000087554 00000 n 
+0000087810 00000 n 
+0000088071 00000 n 
+0000088349 00000 n 
+0000088628 00000 n 
+0000089173 00000 n 
+0000089745 00000 n 
+0000090344 00000 n 
+0000090943 00000 n 
+0000091556 00000 n 
+0000092331 00000 n 
+0000092949 00000 n 
+0000093233 00000 n 
+0000093847 00000 n 
+0000094293 00000 n 
+0000094740 00000 n 
+0000095203 00000 n 
+0000095666 00000 n 
+0000096010 00000 n 
+0000096482 00000 n 
+0000097153 00000 n 
+0000097828 00000 n 
+0000098503 00000 n 
+0000099196 00000 n 
+0000100004 00000 n 
+0000100697 00000 n 
+0000101646 00000 n 
+0000102549 00000 n 
+0000103283 00000 n 
+0000103876 00000 n 
+0000104471 00000 n 
+0000105083 00000 n 
+0000105695 00000 n 
+0000105956 00000 n 
+0000106221 00000 n 
+0000106505 00000 n 
+0000106784 00000 n 
+0000107572 00000 n 
+0000108202 00000 n 
+0000108777 00000 n 
+0000109355 00000 n 
+0000109949 00000 n 
+0000110665 00000 n 
+0000111262 00000 n 
+0000111542 00000 n 
+0000112160 00000 n 
+0000112642 00000 n 
+0000113123 00000 n 
+0000113622 00000 n 
+0000114121 00000 n 
+0000114587 00000 n 
+0000115165 00000 n 
+0000115648 00000 n 
+0000015108 00000 n 
+0000015361 00000 n 
+0000015613 00000 n 
+0000015836 00000 n 
+0000016088 00000 n 
+0000016462 00000 n 
+0000016980 00000 n 
+0000017364 00000 n 
+0000017540 00000 n 
+0000017794 00000 n 
+0000018053 00000 n 
+0000018428 00000 n 
+0000019131 00000 n 
+0000019942 00000 n 
+0000020718 00000 n 
+0000020950 00000 n 
+0000021280 00000 n 
+0000021614 00000 n 
+0000021924 00000 n 
+0000022189 00000 n 
+0000022416 00000 n 
+0000022632 00000 n 
+0000022845 00000 n 
+0000023077 00000 n 
+0000023675 00000 n 
+0000023980 00000 n 
+0000024462 00000 n 
+0000025126 00000 n 
+0000025452 00000 n 
+0000025978 00000 n 
+0000026665 00000 n 
+0000026976 00000 n 
+0000027763 00000 n 
+0000028395 00000 n 
+0000028640 00000 n 
+0000028904 00000 n 
+0000029159 00000 n 
+0000029409 00000 n 
+0000029664 00000 n 
+0000030172 00000 n 
+0000031141 00000 n 
+0000031466 00000 n 
+0000032062 00000 n 
+0000032545 00000 n 
+0000033057 00000 n 
+0000033322 00000 n 
+0000033574 00000 n 
+0000034069 00000 n 
+0000034328 00000 n 
+0000034545 00000 n 
+0000034930 00000 n 
+0000035288 00000 n 
+0000035521 00000 n 
+0000036081 00000 n 
+0000036440 00000 n 
+0000037002 00000 n 
+0000037468 00000 n 
+0000038051 00000 n 
+0000038567 00000 n 
+0000039219 00000 n 
+0000039461 00000 n 
+0000039873 00000 n 
+0000040170 00000 n 
+0000040591 00000 n 
+0000040871 00000 n 
+0000041180 00000 n 
+0000041587 00000 n 
+0000041831 00000 n 
+0000042058 00000 n 
+0000042307 00000 n 
+0000042562 00000 n 
+0000042770 00000 n 
+0000042992 00000 n 
+0000043630 00000 n 
+0000044234 00000 n 
+0000044720 00000 n 
+0000045316 00000 n 
+0000045874 00000 n 
+0000046258 00000 n 
+0000046963 00000 n 
+0000047403 00000 n 
+0000047658 00000 n 
+0000048046 00000 n 
+0000048469 00000 n 
+0000048689 00000 n 
+0000049278 00000 n 
+0000049731 00000 n 
+0000050270 00000 n 
+0000050858 00000 n 
+0000051476 00000 n 
+0000051866 00000 n 
+0000052495 00000 n 
+0000052890 00000 n 
+0000053337 00000 n 
+0000053644 00000 n 
+0000054066 00000 n 
+0000054457 00000 n 
+0000054889 00000 n 
+0000055281 00000 n 
+0000055815 00000 n 
+0000056032 00000 n 
+0000056563 00000 n 
+0000057026 00000 n 
+0000057380 00000 n 
+0000057651 00000 n 
+0000057950 00000 n 
+0000058220 00000 n 
+0000058438 00000 n 
+0000058655 00000 n 
+0000059192 00000 n 
+0000059428 00000 n 
+0000059676 00000 n 
+0000059924 00000 n 
+0000060148 00000 n 
+0000061208 00000 n 
+0000061467 00000 n 
+0000061727 00000 n 
+0000061988 00000 n 
+0000062212 00000 n 
+0000062444 00000 n 
+0000062674 00000 n 
+0000063128 00000 n 
+0000063569 00000 n 
+0000063986 00000 n 
+0000064274 00000 n 
+0000064823 00000 n 
+0000065529 00000 n 
+0000065885 00000 n 
+0000066342 00000 n 
+0000066560 00000 n 
+0000066837 00000 n 
+0000067687 00000 n 
+0000068367 00000 n 
+0000068807 00000 n 
+0000069365 00000 n 
+0000069625 00000 n 
+0000070142 00000 n 
+0000070605 00000 n 
+0000071163 00000 n 
+0000071535 00000 n 
+0000071780 00000 n 
+0000072704 00000 n 
+0000072953 00000 n 
+0000073756 00000 n 
+0000074401 00000 n 
+0000074684 00000 n 
+0000074919 00000 n 
+0000075689 00000 n 
+0000075902 00000 n 
+0000076415 00000 n 
+0000076701 00000 n 
+0000077116 00000 n 
+0000077698 00000 n 
+0000077927 00000 n 
+0000078311 00000 n 
+0000078661 00000 n 
+0000078885 00000 n 
+0000079336 00000 n 
+0000079587 00000 n 
+0000080156 00000 n 
+0000080440 00000 n 
+0000080846 00000 n 
+0000081330 00000 n 
+0000082067 00000 n 
+0000082589 00000 n 
+0000082946 00000 n 
+0000083303 00000 n 
+0000083673 00000 n 
+0000084215 00000 n 
+0000084591 00000 n 
+0000085230 00000 n 
+0000085552 00000 n 
+0000086297 00000 n 
+0000086599 00000 n 
+0000086898 00000 n 
+0000087213 00000 n 
+0000087530 00000 n 
+0000087786 00000 n 
+0000088047 00000 n 
+0000088325 00000 n 
+0000088604 00000 n 
+0000089149 00000 n 
+0000089721 00000 n 
+0000090320 00000 n 
+0000090919 00000 n 
+0000091532 00000 n 
+0000092307 00000 n 
+0000092925 00000 n 
+0000093209 00000 n 
+0000093823 00000 n 
+0000094269 00000 n 
+0000094716 00000 n 
+0000095179 00000 n 
+0000095642 00000 n 
+0000095986 00000 n 
+0000096458 00000 n 
+0000097129 00000 n 
+0000097804 00000 n 
+0000098479 00000 n 
+0000099172 00000 n 
+0000099980 00000 n 
+0000100673 00000 n 
+0000101622 00000 n 
+0000102525 00000 n 
 0000103259 00000 n 
-0000104000 00000 n 
-0000104598 00000 n 
-0000105198 00000 n 
-0000105815 00000 n 
-0000106432 00000 n 
-0000106694 00000 n 
-0000106960 00000 n 
-0000107245 00000 n 
-0000107525 00000 n 
-0000108321 00000 n 
-0000108957 00000 n 
-0000109537 00000 n 
-0000110120 00000 n 
-0000110719 00000 n 
-0000111442 00000 n 
-0000112044 00000 n 
-0000112325 00000 n 
-0000112948 00000 n 
-0000113434 00000 n 
-0000113919 00000 n 
-0000114422 00000 n 
-0000114925 00000 n 
-0000115395 00000 n 
-0000115978 00000 n 
-0000116465 00000 n 
-0000015183 00000 n 
-0000015437 00000 n 
-0000015690 00000 n 
-0000015914 00000 n 
-0000016167 00000 n 
-0000016543 00000 n 
-0000017065 00000 n 
-0000017452 00000 n 
-0000017628 00000 n 
-0000017883 00000 n 
-0000018143 00000 n 
-0000018520 00000 n 
-0000019229 00000 n 
-0000020048 00000 n 
-0000020831 00000 n 
-0000021064 00000 n 
-0000021396 00000 n 
-0000021732 00000 n 
-0000022044 00000 n 
-0000022310 00000 n 
-0000022538 00000 n 
-0000022754 00000 n 
-0000022967 00000 n 
-0000023200 00000 n 
-0000023803 00000 n 
-0000024110 00000 n 
-0000024596 00000 n 
-0000025266 00000 n 
-0000025594 00000 n 
-0000026124 00000 n 
-0000026817 00000 n 
-0000027130 00000 n 
-0000027925 00000 n 
-0000028563 00000 n 
-0000028809 00000 n 
-0000029074 00000 n 
-0000029330 00000 n 
-0000029581 00000 n 
-0000029837 00000 n 
-0000030349 00000 n 
-0000031328 00000 n 
-0000031655 00000 n 
-0000032256 00000 n 
-0000032743 00000 n 
-0000033259 00000 n 
-0000033525 00000 n 
-0000033778 00000 n 
-0000034277 00000 n 
-0000034537 00000 n 
-0000034754 00000 n 
-0000035142 00000 n 
-0000035502 00000 n 
-0000035736 00000 n 
-0000036301 00000 n 
-0000036662 00000 n 
-0000037229 00000 n 
-0000037699 00000 n 
-0000038287 00000 n 
-0000038807 00000 n 
-0000039465 00000 n 
-0000039708 00000 n 
-0000040123 00000 n 
-0000040421 00000 n 
-0000040845 00000 n 
-0000041126 00000 n 
-0000041437 00000 n 
-0000041847 00000 n 
-0000042092 00000 n 
-0000042320 00000 n 
-0000042570 00000 n 
-0000042826 00000 n 
-0000043034 00000 n 
-0000043257 00000 n 
-0000043901 00000 n 
-0000044510 00000 n 
-0000045000 00000 n 
-0000045601 00000 n 
-0000046164 00000 n 
-0000046551 00000 n 
-0000047263 00000 n 
-0000047706 00000 n 
-0000047962 00000 n 
-0000048353 00000 n 
-0000048779 00000 n 
-0000049000 00000 n 
-0000049594 00000 n 
-0000050050 00000 n 
-0000050593 00000 n 
-0000051186 00000 n 
-0000051809 00000 n 
-0000052202 00000 n 
-0000052837 00000 n 
-0000053235 00000 n 
-0000053685 00000 n 
-0000053994 00000 n 
-0000054419 00000 n 
-0000054813 00000 n 
-0000055248 00000 n 
-0000055643 00000 n 
-0000056181 00000 n 
-0000056398 00000 n 
-0000056933 00000 n 
-0000057400 00000 n 
-0000057756 00000 n 
-0000058028 00000 n 
-0000058328 00000 n 
-0000058599 00000 n 
-0000058817 00000 n 
-0000059034 00000 n 
-0000059575 00000 n 
-0000059812 00000 n 
-0000060061 00000 n 
-0000060310 00000 n 
-0000060535 00000 n 
-0000061606 00000 n 
-0000061866 00000 n 
-0000062127 00000 n 
-0000062389 00000 n 
-0000062614 00000 n 
-0000062847 00000 n 
-0000063078 00000 n 
-0000063535 00000 n 
-0000063979 00000 n 
-0000064399 00000 n 
-0000064688 00000 n 
-0000065242 00000 n 
-0000065955 00000 n 
-0000066313 00000 n 
-0000066773 00000 n 
-0000066991 00000 n 
-0000067269 00000 n 
-0000068127 00000 n 
-0000068813 00000 n 
-0000069256 00000 n 
-0000069819 00000 n 
-0000070080 00000 n 
-0000070601 00000 n 
-0000071068 00000 n 
-0000071631 00000 n 
-0000072005 00000 n 
-0000072251 00000 n 
-0000073184 00000 n 
-0000073434 00000 n 
-0000074245 00000 n 
-0000074896 00000 n 
-0000075180 00000 n 
-0000075416 00000 n 
-0000076193 00000 n 
-0000076406 00000 n 
-0000076923 00000 n 
-0000077210 00000 n 
-0000077628 00000 n 
-0000078215 00000 n 
-0000078445 00000 n 
-0000078832 00000 n 
-0000079184 00000 n 
-0000079409 00000 n 
-0000079863 00000 n 
-0000080115 00000 n 
-0000080689 00000 n 
-0000080974 00000 n 
-0000081383 00000 n 
-0000081871 00000 n 
-0000082615 00000 n 
-0000083141 00000 n 
-0000083500 00000 n 
-0000083859 00000 n 
-0000084231 00000 n 
-0000084777 00000 n 
-0000085155 00000 n 
-0000085800 00000 n 
-0000086124 00000 n 
-0000086876 00000 n 
-0000087180 00000 n 
-0000087480 00000 n 
-0000087797 00000 n 
-0000088116 00000 n 
-0000088373 00000 n 
-0000088635 00000 n 
-0000088914 00000 n 
-0000089194 00000 n 
-0000089744 00000 n 
-0000090321 00000 n 
-0000090925 00000 n 
-0000091529 00000 n 
-0000092147 00000 n 
-0000092929 00000 n 
-0000093552 00000 n 
-0000093837 00000 n 
-0000094456 00000 n 
-0000094905 00000 n 
-0000095355 00000 n 
-0000095822 00000 n 
-0000096289 00000 n 
-0000096635 00000 n 
-0000097111 00000 n 
-0000097788 00000 n 
-0000098469 00000 n 
-0000099150 00000 n 
-0000099849 00000 n 
-0000100665 00000 n 
-0000101364 00000 n 
-0000102323 00000 n 
-0000103235 00000 n 
-0000103976 00000 n 
-0000104574 00000 n 
-0000105174 00000 n 
-0000105791 00000 n 
-0000106408 00000 n 
-0000106670 00000 n 
-0000106936 00000 n 
-0000107221 00000 n 
-0000107501 00000 n 
-0000108297 00000 n 
-0000108933 00000 n 
-0000109513 00000 n 
-0000110096 00000 n 
-0000110695 00000 n 
-0000111418 00000 n 
-0000112020 00000 n 
-0000112301 00000 n 
-0000112924 00000 n 
-0000113410 00000 n 
-0000113895 00000 n 
-0000114398 00000 n 
-0000114901 00000 n 
-0000115371 00000 n 
-0000115954 00000 n 
-0000116441 00000 n 
-0000116681 00000 n 
-0000119579 00000 n 
-0000119017 00000 n 
-0000119058 00000 n 
-0000119105 00000 n 
-0000119218 00000 n 
-0000119321 00000 n 
+0000103852 00000 n 
+0000104447 00000 n 
+0000105059 00000 n 
+0000105671 00000 n 
+0000105932 00000 n 
+0000106197 00000 n 
+0000106481 00000 n 
+0000106760 00000 n 
+0000107548 00000 n 
+0000108178 00000 n 
+0000108753 00000 n 
+0000109331 00000 n 
+0000109925 00000 n 
+0000110641 00000 n 
+0000111238 00000 n 
+0000111518 00000 n 
+0000112136 00000 n 
+0000112618 00000 n 
+0000113099 00000 n 
+0000113598 00000 n 
+0000114097 00000 n 
+0000114563 00000 n 
+0000115141 00000 n 
+0000115624 00000 n 
+0000115863 00000 n 
+0000118761 00000 n 
+0000118199 00000 n 
+0000118240 00000 n 
+0000118287 00000 n 
+0000118400 00000 n 
+0000118503 00000 n 
 trailer
 << 
    /Size 486
@@ -4510,5 +4510,5 @@ trailer
    /Info 1 0 R
 >>
 startxref
-119700
+118882
 %%EOF

--- a/Standard/Standard.bib
+++ b/Standard/Standard.bib
@@ -12,7 +12,8 @@
 	Date-Modified = {2015-10-29 09:24:14 +0000},
 	Journal = {Enzyklopedie der Wirtschaftsinformatik},
 	Title = {Industrie 4.0},
-	Year = {2015}}
+	Year = {2015},
+}
 	
 @article{meissner2013,
 	Author = {J. Mei{\ss}ner},
@@ -23,7 +24,8 @@
 	Pages = {21-24},
 	Title = {{Cyberphysische Produktionssysteme}},
 	Volume = {18},
-	Year = {2013}}
+	Year = {2013},
+}
 
 
 @book{Schaller98,
@@ -32,7 +34,8 @@
 	Date-Modified = {2020-04-18 13:32:05 +0200},
 	Publisher = {Dissertation Universit{\"a}t Bamberg},
 	Title = {{Organisationsverwaltung in CSCW-Systemen}},
-	Year = 1998}
+	Year = {1998},
+}
 
 @inproceedings{Lawall2014,
 	Address = {Heidelberg},
@@ -49,7 +52,8 @@
 	Publisher = {Springer-Verlag},
 	Timestamp = {2014.02.25},
 	Title = {Cross-Organizational and Context-Sensitive Modeling of Organizational Dependencies in C-ORG},
-	Year = {2014}}
+	Year = {2014},
+}
 
 @incollection{Lawall2014d,
 	Author = {Lawall, Alexander and Schaller, Thomas and Reichelt, Dominik},
@@ -70,7 +74,8 @@
 	Url = {http://dx.doi.org/10.1007/978-3-662-44860-1_5},
 	Volume = {191},
 	Year = {2014},
-	Bdsk-Url-1 = {http://dx.doi.org/10.1007/978-3-662-44860-1_5}}
+	Bdsk-Url-1 = {http://dx.doi.org/10.1007/978-3-662-44860-1_5},
+}
 
 @inproceedings{Lawall2013,
 	Address = {Heidelberg},
@@ -83,7 +88,8 @@
 	Publisher = {Springer},
 	Timestamp = {2013.07.10},
 	Title = {Integration of Dynamic Role Resolution within the S-BPM Approach},
-	Year = {2013}}
+	Year = {2013},
+}
 
 @inproceedings{Lawall2011,
 	Address = {Berlin},
@@ -105,7 +111,8 @@
 	Url = {http://opus.kobv.de/tfhwildau/volltexte/2011/117/},
 	Urn = {urn:nbn:de:kobv:526-opus-1175},
 	Year = {2011},
-	Bdsk-Url-1 = {http://opus.kobv.de/tfhwildau/volltexte/2011/117/}}
+	Bdsk-Url-1 = {http://opus.kobv.de/tfhwildau/volltexte/2011/117/},
+}
 
 @inproceedings{Lawall2014c,
 	Author = {Lawall, A. and Schaller, T. and Reichelt, D.},
@@ -119,7 +126,8 @@
 	Timestamp = {2014.03.28},
 	Title = {Local-Global Agent Failover Based on Organizational Models},
 	Volume = {3},
-	Year = {2014}}
+	Year = {2014},
+}
 
 @inproceedings{Lawall2014a,
 	Author = {Lawall, Alexander and Reichelt, Dominik and Schaller, Thomas},
@@ -133,7 +141,8 @@
 	Timestamp = {2014.03.28},
 	Title = {Propagation of Agents to Trusted Organizations},
 	Volume = {3},
-	Year = {2014}}
+	Year = {2014},
+}
 
 @inproceedings{Lawall2014b,
 	Abstract = {One prerequisite of cross-organizational business processes are well-defined
@@ -163,13 +172,15 @@
 	Title = {Restricted Relations between Organizations for Cross-Organizational Processes},
 	Volume = {2},
 	Year = {2014},
-	Bdsk-Url-1 = {https://doi.org/10.1109/CBI.2014.8}}
+	Bdsk-Url-1 = {https://doi.org/10.1109/CBI.2014.8},
+}
 
 @book{Keenan:1976aa,
 	Author = {Keenan, E. L.},
 	Date-Added = {2019-08-22 12:02:39 +0200},
 	Date-Modified = {2019-08-22 12:05:58 +0200},
-	Year = {1976}}
+	Year = {1976},
+}
 
 
 
@@ -523,7 +534,7 @@
 @Article{article:SUbjetorientiertBPM,
 	author = {Schmidt, W and Fleischmann A. and Gilbert O.},
 	title = {Subjektorientiertes Geschaeftsprozessmanagement},
-	journal= {HMD  Praxis der Wirtschaftsinformatik}
+	journal= {HMD  Praxis der Wirtschaftsinformatik},
 	volume = {Heft 266},
 	year = {2009},
 }
@@ -577,7 +588,7 @@
 	title = {BLOCKBENCH: A Framework for Analyzing Private Blockchains},
 	booktitle = {Proceedings of the 2017 ACM International Conference on Management, SIGMOD '17},
 	year = {2017},
-	publisher {SIGMOD}
+	publisher = {SIGMOD},
 }
 
 
@@ -601,9 +612,9 @@
 	author = {Accorsi, R. and Ulrich, M. and Van der Aalst, W.},
 	title = {Process Mining},
 	journal = {Informatik Spektrum},
-	Volume = {35}
+	Volume = {35},
 	year = {2012},
-	pages = {354-359}
+	pages = {354-359},
 }
 
 
@@ -612,25 +623,26 @@
 	author = {Boerger, E.},
 	title = {Approaches to modeling business processes: a critical analysis of BPMN, workflow patterns and YAWL},
 	journal = {Journal of Software and Systems Modeling},
-	Volume = {11}
+	Volume = {11},
 	year = {2012},
-	pages = {305-318}
+	pages = {305-318},
+}
 
 
 @InProceedings{article:ProcessPerfInd,
-	author = {Del-Río-Ortega, A., De Reyna, M., Durán Toro, A., Ruiz-Cortés, A.},
+	author = {Del-Río-Ortega, A. and De Reyna, M. and Durán Toro, A. and Ruiz-Cortés, A.},
 	title = {Defining Process Performance Indicators by Using Templates and Patterns},
 	booktitle = {BPM 2012},
 	year = {2012},
 	editor = {Barros, A. and Gal, A. and Kindler, E.  },
-	series{LNCS 7481}
+	series = {LNCS 7481},
 	publisher = {Springer Verlag},
 	pages = {223-228},
 }
 
 
 @InProceedings{book:AnalytInfSys,
-	author = {Dinter, B.and Bucher, T.},
+	author = {Dinter, B. and Bucher, T.},
 	title = {Business Performance Management},
 	booktitle = {Analytische Informationssysteme},
 	year = {2006},
@@ -644,9 +656,9 @@
 	author = {Eckert, M. and Bry, F.},
 	title = {Complex Event Processing (CEP)},
 	journal = {Informatik Spektrum},
-	volume = {32}
+	volume = {32},
 	year = {2009},
-	pages = {163-167}
+	pages = {163-167},
 }
 
 
@@ -807,7 +819,7 @@ author = {R., Ramsin and R. F., Paige},
 title = {Process-centered Review of Object Oriented Software Development Methodologies},
 booktitle = {ACM Computing Surveys},
 year = {2008},
-volume = {Volume-40, Number 1}
+volume = {Volume-40, Number 1},
 }
 
 
@@ -817,7 +829,7 @@ author = {M. E. Conway},
 title = {How do Committees Invent?},
 booktitle = {Datamation},
 year = {1968},
-pages = {28–31}
+pages = {28–31},
 }
 
 
@@ -1057,7 +1069,7 @@ pages = {214-219},
 author = {Janiesch, C. and Matzner, M. and Müller, O.},
 title = {A Blueprint for Event-driven Business Activity Management},
 booktitle = {9th International Conference on Business Process Management (BPM)},
-editor = {Rinderle, S. and Toumani, F. and and Wolf, K.}
+editor = {Rinderle, S. and Toumani, F. and and Wolf, K.},
 year = {2011},
 publisher = {Springer},
 pages = {17-28},
@@ -1099,7 +1111,7 @@ pages = {142-150},
 author = {Schmidt, W. and Fleischmann, A.},
 title = {Business Process Monitoring with S-BPM},
 booktitle = {Proceedings of the 5th International Conference S-BPM ONE 2013, Computer and Information Sciences (CCIS), No. 360},
-editor = {Fischer, H. and Schneeberger, J.}
+editor = {Fischer, H. and Schneeberger, J.},
 year = {2013},
 publisher = {Springer},
 }
@@ -1184,7 +1196,7 @@ pages = {1--4},
 isbn = {978-1-4503-4071-7},
 editor = {Sanz, Jorge L.},
 booktitle = {S-BPM ONE 2016},
-year = {2016}
+year = {2016},
 }
 
 @ARTICLE{article:Interacting-Services,
@@ -1207,7 +1219,7 @@ publisher = {Oldenbourg Wissenschaftsverlag},
 @Book{book:BPMN-Standard,
 author = {{Open Management Group} and (OMG)},
 title = {Business Process Model and Notation (BPMN)},
-url = {http://www.omg.org/spec/BPMN/2.0}
+url = {http://www.omg.org/spec/BPMN/2.0},
 year = {2011},
 }
 
@@ -1399,8 +1411,8 @@ title = {The Theory of Conceptual Modelling and Foundations of Conceptual Modell
 pages = {543--579},
 editor = {Embley, D, W, and Thalheim, B.},
 booktitle = {Handbook of Conceptual Modeling},
-Publisher = {Springer}
-year = {2011}
+Publisher = {Springer},
+year = {2011},
 }
 
 @Book{book:Model-Handbook,
@@ -1711,7 +1723,9 @@ Date-Added = {2020-04-18 13:32:05 +0200},
 Date-Modified = {2020-04-18 13:32:05 +0200},
 Publisher = {Dissertation Universit{\"a}t Bamberg},
 Title = {{Organisationsverwaltung in CSCW-Systemen}},
-Year = 1998}
+Year = {1998},
+}
+
 
 @Book{book:Realtime-MARTE,
 author = {Hassan Gooma},
@@ -1852,7 +1866,7 @@ booktitle = {S-BPM ONE: Setting the Stage for Subject-Oriented Business Process 
 year = {2010},
 editor = {H. Buchwald, A. Fleischmann, D. Seese, C. Stary},
 series = {Communications in Computer and Information Sience},
-number = {85}
+number = {85},
 publisher = {Springer Verlag},
 }
 

--- a/Standard/Standardbuch-PASS.dep
+++ b/Standard/Standardbuch-PASS.dep
@@ -1,16 +1,19 @@
 \RequireVersions{
-  *{application}{pdfeTeX} {0000/00/00 v0.14021}
-  *{format} {LaTeX2e}     {2020-02-02 v2.e}
-  *{package}{snapshot}    {2012/08/06 v2.13}
-  *{class}  {memoir}      {2020/06/02 v3.7l}
-  *{package}{iftex}       {2020/03/06 v1.0d}
+  *{application}{TeX}     {1990/03/25 v3.x}
+  *{format} {LaTeX2e}     {2018-12-01 v2.e}
+  *{package}{snapshot}    {2002/03/05 v1.14}
+  *{class}  {memoir}      {2018/12/12 v3.7h}
+  *{package}{ifpdf}       {2018/09/07 v3.3}
+  *{package}{ifetex}      {2018/03/31 v1.2a}
+  *{package}{ifxetex}     {2010/09/12 v0.6}
+  *{package}{ifluatex}    {2016/05/16 v1.4}
   *{file}   {mem11.clo}   {2008/01/30 v0.3}
-  *{package}{array}       {2019/08/31 v2.4l}
+  *{package}{array}       {2018/12/30 v2.4k}
   *{package}{dcolumn}     {2014/10/28 v1.06}
   *{package}{delarray}    {2014/10/28 v1.01}
-  *{package}{tabularx}    {2020/01/15 v2.11c}
-  *{package}{textcase}    {2019/09/14 v1.00}
+  *{package}{tabularx}    {2016/02/03 v2.11b}
   *{package}{fontenc}     {0000/00/00 v0.0}
+  *{file}   {t1enc.def}   {2018/08/11 v2.0j}
   *{package}{todonotes}   {2018/11/22 v0.0}
   *{package}{ifthen}      {2014/09/29 v1.1c}
   *{package}{xkeyval}     {2014/12/03 v2.7a}
@@ -18,24 +21,24 @@
   *{package}{xcolor}      {2016/05/11 v2.12}
   *{file}   {color.cfg}   {2016/01/02 v1.6}
   *{file}   {pdftex.def}  {2018/01/08 v1.0l}
-  *{package}{tikz}        {2020/01/08 v3.1.5b}
-  *{package}{pgf}         {2020/01/08 v3.1.5b}
-  *{package}{pgfrcs}      {2020/01/08 v3.1.5b}
+  *{package}{tikz}        {2019/02/02 v3.1.1}
+  *{package}{pgf}         {2019/02/02 v3.1.1}
+  *{package}{pgfrcs}      {2019/02/02 v3.1.1}
   *{package}{everyshi}    {2001/05/15 v3.00}
   *{file}   {pgfrcs.code.tex}{0000/00/00 v0.0}
-  *{package}{pgfcore}     {2020/01/08 v3.1.5b}
-  *{package}{graphicx}    {2019/11/30 v1.2a}
-  *{package}{graphics}    {2019/11/30 v1.4a}
+  *{package}{pgfcore}     {2019/02/02 v3.1.1}
+  *{package}{graphicx}    {2017/06/01 v1.1a}
+  *{package}{graphics}    {2017/06/25 v1.2c}
   *{package}{trig}        {2016/01/03 v1.10}
   *{file}   {graphics.cfg}{2016/06/04 v1.11}
-  *{package}{pgfsys}      {2020/01/08 v3.1.5b}
+  *{package}{pgfsys}      {2019/02/02 v3.1.1}
   *{file}   {pgfsys.code.tex}{0000/00/00 v0.0}
-  *{file}   {pgfsyssoftpath.code.tex}{2020/01/08 v3.1.5b}
-  *{file}   {pgfsysprotocol.code.tex}{2020/01/08 v3.1.5b}
+  *{file}   {pgfsyssoftpath.code.tex}{2019/02/02 v3.1.1}
+  *{file}   {pgfsysprotocol.code.tex}{2019/02/02 v3.1.1}
   *{file}   {pgfcore.code.tex}{0000/00/00 v0.0}
-  *{package}{pgfcomp-version-0-65}{2020/01/08 v3.1.5b}
-  *{package}{pgfcomp-version-1-18}{2020/01/08 v3.1.5b}
-  *{package}{pgffor}      {2020/01/08 v3.1.5b}
+  *{package}{pgfcomp-version-0-65}{2019/02/02 v3.1.1}
+  *{package}{pgfcomp-version-1-18}{2019/02/02 v3.1.1}
+  *{package}{pgffor}      {2019/02/02 v3.1.1}
   *{package}{pgfkeys}     {0000/00/00 v0.0}
   *{file}   {pgfkeys.code.tex}{0000/00/00 v0.0}
   *{package}{pgfmath}     {0000/00/00 v0.0}
@@ -44,18 +47,20 @@
   *{file}   {tikz.code.tex}{0000/00/00 v0.0}
   *{package}{calc}        {2017/05/25 v4.3}
   *{package}{morewrites}  {2018/12/29 v0.0}
-  *{package}{expl3}       {2020-06-18 v3}
-  *{file}   {l3backend-pdfmode.def}{2020-06-18 v3}
+  *{package}{expl3}       {2019-02-15 v3}
+  *{file}   {expl3-code.tex}{2019-02-15 v3}
+  *{file}   {l3pdfmode.def}{2019-02-15 v3}
   *{package}{primargs}    {2018/12/29 v0.0}
-  *{package}{changes}     {2020/06/16 v3.2.2}
+  *{package}{changes}     {2019/01/26 v3.1.2}
   *{package}{xifthen}     {2015/11/05 v1.4.0}
   *{package}{xstring}     {2019/02/06 v1.83}
-  *{package}{ulem}        {2019/11/18 v0.0}
+  *{package}{pdfcolmk}    {2016/05/16 v1.3}
+  *{package}{ulem}        {2012/05/18 v0.0}
   *{package}{truncate}    {2001/08/20 v3.6}
-  *{package}{soulutf8}    {2019/12/15 v1.2}
+  *{package}{soulutf8}    {2016/05/16 v1.1}
   *{package}{soul}        {2003/11/17 v2.4}
-  *{package}{infwarerr}   {2019/12/03 v1.5}
-  *{package}{etexcmds}    {2019/12/15 v1.7}
+  *{package}{infwarerr}   {2016/05/16 v1.4}
+  *{package}{etexcmds}    {2016/05/16 v1.6}
   *{package}{memsty}      {2010/02/09 v0.0}
   *{package}{etex}        {2016/08/01 v2.7}
   *{package}{layouts}     {2009/09/02 v2.6d}
@@ -64,36 +69,44 @@
   *{package}{alltt}       {1997/06/16 v2.0g}
   *{package}{latexsym}    {1998/08/17 v2.2e}
   *{package}{memfonts}    {2007/11/13 v1.0}
-  *{package}{pifont}      {2020/03/25 v9.3}
+  *{package}{pifont}      {2005/04/12 v9.2a}
   *{file}   {upzd.fd}     {2001/06/04 v0.0}
   *{file}   {upsy.fd}     {2001/06/04 v0.0}
-  *{package}{amsmath}     {2020/01/20 v2.17e}
+  *{package}{amsmath}     {2018/12/01 v2.17b}
   *{package}{amstext}     {2000/06/29 v2.01}
   *{package}{amsgen}      {1999/11/30 v2.0}
   *{package}{amsbsy}      {1999/11/29 v1.2d}
   *{package}{amsopn}      {2016/03/08 v2.02}
   *{package}{fontenc}     {0000/00/00 v0.0}
-  *{file}   {t1ppl.fd}    {2001/06/04 v1/ppl.}
-  *{package}{hyperref}    {2020-05-15 v7.00e}
-  *{package}{ltxcmds}     {2019/12/15 v1.24}
-  *{package}{pdftexcmds}  {2020-06-04 v0.32}
-  *{package}{kvsetkeys}   {2019/12/15 v1.18}
-  *{package}{kvdefinekeys}{2019-12-19 v1.6}
-  *{package}{pdfescape}   {2019/12/09 v1.15}
-  *{package}{hycolor}     {2020-01-27 v1.10}
-  *{package}{letltxmacro} {2019/12/03 v1.6}
-  *{package}{auxhook}     {2019-12-17 v1.6}
-  *{package}{kvoptions}   {2019/11/29 v3.13}
-  *{file}   {pd1enc.def}  {2020-05-15 v7.00e}
-  *{package}{intcalc}     {2019/12/15 v1.3}
-  *{package}{bitset}      {2019/12/09 v1.3}
-  *{package}{bigintcalc}  {2019/12/15 v1.5}
-  *{package}{atbegshi}    {2019/12/05 v1.19}
-  *{package}{memhfixc}    {2019/10/24 v1.18}
-  *{file}   {hpdftex.def} {2020-05-15 v7.00e}
-  *{package}{atveryend}   {2019-12-11 v1.11}
-  *{package}{rerunfilecheck}{2019/12/05 v1.9}
-  *{package}{uniquecounter}{2019/12/15 v1.4}
+  *{file}   {t1enc.def}   {2018/08/11 v2.0j}
+  *{package}{hyperref}    {2018/11/30 v6.88e}
+  *{package}{hobsub-hyperref}{2016/05/16 v1.14}
+  *{package}{hobsub-generic}{2016/05/16 v1.14}
+  *{package}{hobsub}      {2016/05/16 v1.14}
+  *{package}{ltxcmds}     {2016/05/16 v1.23}
+  *{package}{ifvtex}      {2016/05/16 v1.6}
+  *{package}{intcalc}     {2016/05/16 v1.2}
+  *{package}{kvsetkeys}   {2016/05/16 v1.17}
+  *{package}{kvdefinekeys}{2016/05/16 v1.4}
+  *{package}{pdftexcmds}  {2018/09/10 v0.29}
+  *{package}{pdfescape}   {2016/05/16 v1.14}
+  *{package}{bigintcalc}  {2016/05/16 v1.4}
+  *{package}{bitset}      {2016/05/16 v1.2}
+  *{package}{uniquecounter}{2016/05/16 v1.3}
+  *{package}{letltxmacro} {2016/05/16 v1.5}
+  *{package}{hopatch}     {2016/05/16 v1.3}
+  *{package}{xcolor-patch}{2016/05/16 v0.0}
+  *{package}{atveryend}   {2016/05/16 v1.9}
+  *{package}{atbegshi}    {2016/06/09 v1.18}
+  *{package}{refcount}    {2016/05/16 v3.5}
+  *{package}{hycolor}     {2016/05/16 v1.8}
+  *{package}{auxhook}     {2016/05/16 v1.4}
+  *{package}{kvoptions}   {2016/05/16 v3.12}
+  *{file}   {pd1enc.def}  {2018/11/30 v6.88e}
+  *{file}   {hyperref.cfg}{2002/06/06 v1.2}
+  *{package}{memhfixc}    {2013/05/30 v1.17}
+  *{file}   {hpdftex.def} {2018/11/30 v6.88e}
+  *{package}{rerunfilecheck}{2016/05/16 v1.8}
   *{package}{memlays}     {2002/08/10 v1.0}
   *{package}{titlepages}  {2009/07/09 v1.1}
   *{package}{dpfloat}     {2006/10/05 v0.0}
@@ -102,21 +115,17 @@
   *{package}{wrapfig}     {2003/01/31 v3.6}
   *{package}{hyphenat}    {2009/09/02 v2.3c}
   *{package}{lscape}      {2000/10/22 v3.01}
-  *{package}{listings}    {2020/03/24 v1.8d}
-  *{package}{lstmisc}     {2020/03/24 v1.8d}
-  *{file}   {listings.cfg}{2020/03/24 v1.8d}
-  *{package}{enumitem}    {2019/06/20 v3.9}
-  *{package}{longtable}   {2020/01/07 v4.13}
-  *{package}{pdfpages}    {2020/01/28 v0.5q}
+  *{package}{listings}    {2018/09/02 v1.7}
+  *{package}{lstmisc}     {2018/09/02 v1.7}
+  *{file}   {listings.cfg}{2018/09/02 v1.7}
+  *{package}{enumitem}    {2019/02/04 v3.8}
+  *{package}{longtable}   {2014/10/28 v4.11}
+  *{package}{pdfpages}    {2017/10/31 v0.5l}
   *{package}{eso-pic}     {2018/04/12 v2.0h}
-  *{file}   {pppdftex.def}{2020/01/28 v0.5q}
-  *{package}{caption}     {2020/05/30 v3.4k}
-  *{package}{caption3}    {2020/05/30 v1.12}
-  *{package}{ltcaption}   {2020/05/30 v1.4b}
-  *{package}{lipsum}      {2019/01/02 v2.2}
-  *{package}{xparse}      {2020-05-15 v3}
-  *{file}   {xparse-generic.tex}{0000/00/00 v0.0}
-  *{file}   {lipsum.ltd}  {0000/00/00 v0.0}
+  *{file}   {pppdftex.def}{2017/10/31 v0.5l}
+  *{package}{caption}     {2018/10/06 v3.3-154}
+  *{package}{caption3}    {2018/09/12 v1.8c}
+  *{package}{ltcaption}   {2018/08/26 v1.4-95}
   *{package}{amssymb}     {2013/01/14 v3.01}
   *{package}{amsfonts}    {2013/01/14 v3.01}
   *{package}{program}     {0000/00/00 v0.0}
@@ -124,40 +133,42 @@
   *{file}   {umsa.fd}     {2013/01/14 v3.01}
   *{file}   {umsb.fd}     {2013/01/14 v3.01}
   *{file}   {ueur.fd}     {2013/01/14 v3.01}
-  *{package}{mathtools}   {2020/03/24 v1.24}
+  *{package}{mathtools}   {2018/01/08 v1.21}
   *{package}{mhsetup}     {2017/03/31 v1.3}
   *{package}{minted}      {2017/07/19 v2.5}
   *{package}{fvextra}     {2019/02/04 v1.4}
-  *{package}{etoolbox}    {2019/09/21 v2.5h}
-  *{package}{fancyvrb}    {2020/05/03 v3.6}
+  *{package}{etoolbox}    {2018/08/19 v2.5f}
+  *{package}{fancyvrb}    {2019/01/15 v0.0}
   *{package}{upquote}     {2012/04/19 v1.3}
-  *{package}{textcomp}    {2020/02/02 v2.0n}
+  *{package}{textcomp}    {2018/08/11 v2.0j}
+  *{file}   {ts1enc.def}  {2001/06/05 v3.0e}
+  *{file}   {ts1enc.dfu}  {2018/10/05 v1.2f}
   *{package}{lineno}      {2005/11/02 v4.41}
-  *{package}{shellesc}    {2019/11/08 v1.0c}
+  *{package}{shellesc}    {2016/06/07 v0.02a}
   *{package}{ifplatform}  {2017/10/13 v0.4a}
-  *{package}{catchfile}   {2019/12/09 v1.8}
-  *{package}{ifluatex}    {2019/10/25 v1.5}
-  *{file}   {"Standardbuch-PASS.w18"}{0000/00/00 v0.0}
+  *{package}{catchfile}   {2016/05/16 v1.7}
+  *{file}   {Standardbuch-PASS.w18}{0000/00/00 v0.0}
   *{package}{framed}      {2011/10/22 v0.96:}
   *{package}{float}       {2001/11/08 v1.3d}
-  *{package}{multicol}    {2019/12/09 v1.8y}
-  *{package}{bookmark}    {2019/12/03 v1.28}
-  *{file}   {bkm-pdftex.def}{2019/12/03 v1.28}
   *{package}{xargs}       {2008/03/22 v1.1}
   *{file}   {mathdef.tex} {0000/00/00 v0.0}
-  *{file}   {ts1ppl.fd}   {2001/06/04 v1/ppl.}
-  *{file}   {ueuf.fd}     {2013/01/14 v3.01}
-  *{-------}{Document-specific files:}{----}
+  *{file}   {ts1cmr.fd}   {2014/09/29 v2.5h}
+  *{file}   {t1ppl.fd}    {2001/06/04 v1/ppl.}
   *{file}   {supp-pdf.mkii}{0000/00/00 v0.0}
-  *{package}{epstopdf-base}{2020-01-24 v2.11}
+  *{package}{epstopdf-base}{2016/05/15 v2.6}
+  *{package}{grfext}      {2016/05/16 v1.2}
   *{file}   {epstopdf-sys.cfg}{2010/07/13 v1.3}
-  *{package}{nameref}     {2019/09/16 v2.46}
-  *{package}{refcount}    {2019/12/15 v3.6}
-  *{package}{gettitlestring}{2019/12/15 v1.6}
-  *{package}{ragged2e}    {2019/07/28 v2.2}
+  *{package}{nameref}     {2016/05/21 v2.44}
+  *{package}{gettitlestring}{2016/05/16 v1.5}
+  *{file}   {Standardbuch-PASS.out}{0000/00/00 v0.0}
+  *{file}   {Standardbuch-PASS.out}{0000/00/00 v0.0}
+  *{package}{ragged2e}    {2009/05/21 v2.1}
   *{package}{everysel}    {2011/10/28 v1.2}
-  *{package}{pdflscape}   {2019/12/05 v0.12}
-  *{file}   {figures/i2pm.pdf}{0000/00/00 v0.0}
+  *{package}{pdflscape}   {2016/05/14 v0.11}
+  *{file}   {ts1ppl.fd}   {2001/06/04 v1/ppl.}
+  *{file}   {preface.tex} {0000/00/00 v0.0}
+  *{file}   {Figures/Preface.png}{0000/00/00 v0.0}
+  *{file}   {ueuf.fd}     {2013/01/14 v3.01}
   *{file}   {chapter01.tex}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/OrderComStructure.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/OrderCustomerOrderHandling.jpg}{0000/00/00 v0.0}
@@ -173,7 +184,7 @@
   *{file}   {Figures/Ontology/SubjectInteraction/20181218-Data.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectInteraction/OntoGrSubjectInteraction.jpg}{0000/00/00 v0.0}
   *{file}   {chapter03.tex}{0000/00/00 v0.0}
-  *{file}   {chapter03a}  {0000/00/00 v0.0}
+  *{file}   {chapter03a.tex}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/sendState.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/SendSTateTimer.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/ReceiveState.jpg}{0000/00/00 v0.0}
@@ -192,7 +203,7 @@
   *{file}   {Figures/Ontology/SubjectExecution/20190104-Behavior-describing-component.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/20190109-States.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Ontology/SubjectExecution/20190105-Transitions.jpg}{0000/00/00 v0.0}
-  *{file}   {chapter03b}  {0000/00/00 v0.0}
+  *{file}   {chapter03b.tex}{0000/00/00 v0.0}
   *{file}   {_minted-Standardbuch-PASS/default-pyg-prefix.pygstyle}{0000/00/00 v0.0}
   *{file}   {_minted-Standardbuch-PASS/default.pygstyle}{0000/00/00 v0.0}
   *{file}   {_minted-Standardbuch-PASS/3A53015A4DE50BDA0DE35D6F370582F4F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
@@ -377,7 +388,99 @@
   *{file}   {Figures/Chapter5/ActivityBased/CalcPro.jpg}{0000/00/00 v0.0}
   *{file}   {Figures/Chapter5/ActivityBased/embedding.jpg}{0000/00/00 v0.0}
   *{file}   {appendix.tex}{0000/00/00 v0.0}
-  *{file}   {appendixA}   {0000/00/00 v0.0}
-  *{file}   {appendixB}   {0000/00/00 v0.0}
-  *{file}   {review.tex}  {0000/00/00 v0.0}
+  *{file}   {appendixA.tex}{0000/00/00 v0.0}
+  *{file}   {appendixB.tex}{0000/00/00 v0.0}
+  *{file}   {appendixC.tex}{0000/00/00 v0.0}
+  *{file}   {Figures/CoreASM/ArchitekturKonsoleCoreASM.pdf}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/4249DAE743D794FE36A3CA47830F45E0F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/C96E57009F6286734B033C8946FAF1FD07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/8F4BBCFE929292CA13A8838FD9DD792907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1907B832D1EE07A12E4D807B99C2B275F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/743D1C1D6895156F0EE56F8A22CCD304F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1D7416626BED569446F1C977841CD13DF60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/E74A12918BE7907FFD849EE069437B56F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/90DCDB941E1E2C75D7CADF882BC7413707B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/0B513838532880655DAD50F8C96C25C107B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/94D617105F979352D1B2C14F094CD35F07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/30E71EF338C9B1A55EC2ED1817249028F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/29BB952B95ACEBE88888A5D65C1FE08B07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/DAAB4A6D9AD6BDF4399CB51DC227F3BA07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/A4D6ABB73E33142B7AC036547F9EE36407B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/B5CA6BCD31CB23EC0D4D2813B1C91CE6F60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/E7E2CB3C1F12F19DEC539178354B2CA907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/9D63C76062869B5F8B427D619C40F1E007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {ts1lmtt.fd}  {2009/10/30 v1.6}
+  *{file}   {_minted-Standardbuch-PASS/6FA22F6FCBF482F866F914CAE2EDDA3E07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/D5506E90740A77CCA1D54382F780D11F07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/038C7DD45F64033CCABD6BE01C9C4B3AF60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/231E88820080FB25AF747BD25E56DD7707B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/869D06AD17D15DC95BBAD3803E866DCC07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/27D7127E53D10A669A156D11FB2C427707B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/38CEE53E65F0154D5B9922815A74D04507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/A4A962B18375D7D7A849254973F7676007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/3DD9C2F198E8787E7CAA99879E416E1007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1C346F45BD3A2B6937AC8014B008101007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/33739C7CF8B24A9CD80253F9D25FEF8CF60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/18BCEB697F71103D321451A12F9DDE8807B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/49F5ABBCE0FC700FC98736A350070C3407B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/AFEFDFE31F76E37F85F35F8BEB17D80A07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/C00228CFEDFE490F47B1FCD8527F587607B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/3E36219CAF2D84CDB8EC6C1F65874A4C07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/4EBA81C2E802C3D1B3EDA15CAEF8A2AB07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/ACBBE7E8AF8D35BFB6A7893589301B9307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/999F24BF8EA8705F3045B285FA3FC44507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/7C9CFC35371DE94AB16F374EA5CF273607B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/3014693327FC0CB4ECF87FCD0405E0F307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/66A1692F4E31881EB431EFA6338BDF9507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/7EA83EED2428B028498A31C5A33372A607B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/53E1252D06F4299EA90B337FB3C8DFD507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/CE8059044D0849037B6C77CF4ADD619207B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/8BB6873199C9857487A9C9C24A03E97907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/D85C2F3A2DCA1C08BF1006184A80A3C507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/22C25936B0C90D1639BC1F108E3DE84907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/CB92B2FBED3CC8E3AE3817C5B9E0149F07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/6DCD8838AF220558D62FA8F7A1034F2C07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/BADE44044C191B8E77664AA58849700107B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1830A18C9BA8EFFAC7EB250040D122DA07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/C74EC905739BA0798C0BE7C23872656E07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/B24764385B49D3460D9031ED8A2E67F007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1AD37FBDE8FDC7B9476BD3A85816E2D507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/CBAA82FD1FF291E323EFF7441CDFA09407B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/752B77602DFA22EF12E5C5571DA2226407B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1699B38145A06FD0CEE5938237B9C49A07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/BDEB57CA63144993B43851474456E26F07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/096E9F42BCAE873F5A0F24DD4F9B138807B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/F1B119837F8B93FD6EF1F5DC29C97BBE07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/39A4C02292D730E922236D44A822CB1207B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/4A2A91E8F955506DF84D43705F808E9007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/4584D07D7634E1FF0CB3344260105F7607B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/94BB8832B88853430B8CE17D4FAD3AEA07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/48392FFBCBFC5E477C78F7AA22D9479507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/043258A359CA5787D0DEDB85912FE0CE07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/8AB93CEEFC72D29AD5C3FADE3940E0A207B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/AACC4195C6446675968BE48AA4DF72AD07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/EC4BAA8BE359F472CCCE7F877924FFB707B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/0274FDABDC4185E29A9839B319ED63DF07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/60DC2B5F44230930A1E92E123CB6222307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/43AB20A0C17BB4CACEC1DEC1FC2A7D6107B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1C8661B3612E2C04013B0AE0254AB8F907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/982E40E710C7914CE225EBA1C9A421D307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/D33674D2458E67F5AEDAA3FDF3344EB507B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/C363E62BCB6137ABB4F046B02CF7FBB307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/469F9CC92FBFBE872D301598B3CB888707B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1E1E59EE2448AA19FDCE1EFFE95D261F07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/BDEC9EB67D36A2DD18563D71DB998D3307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/85523F447D6C2F0AFEFE20301B54B89AF60A6A8E94233316289A6D23C8A042CF.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/1BB88BBFD5068CE0F23E19C424A4D24007B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/34ECFD4C5E3F5DE96F65E0ACD2283F9407B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/6EBE99A2F44513C323EF3896E0A503AB07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/E69D261FEDFA3EC4F9908511254DE48B07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/3493FFF03B0E602847B12AABF5DC2E9807B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/18AB5062EFA7F421047B1182C12D3BD807B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/9051DE8F29AFE146B0CB9F097B725E9307B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/8AF37D4978EFC5002ABFB712580036FE07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/32ED0023F315AC4B61A17BDB1C04829B07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/AC84A57CEA3336B7EF5627AA0BCCAEE907B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {_minted-Standardbuch-PASS/A5468843F999A0E60C1FFF02C1F05EAE07B37CD1344A9BFEB3BB8D600B282F2F.pygtex}{0000/00/00 v0.0}
+  *{file}   {Standardbuch-PASS.bbl}{0000/00/00 v0.0}
 }

--- a/Standard/Standardbuch-PASS.loc
+++ b/Standard/Standardbuch-PASS.loc
@@ -1,4 +1,4 @@
-\ChangesListline {added}{Added\nobreakspace {}(AF)}{Added text}{167}
-\ChangesListline {deleted}{Deleted\nobreakspace {}(WS)}{Here is the text to be deleted}{167}
-\ChangesListline {replaced}{Replaced\nobreakspace {}(CS)}{new text}{167}
-\ChangesListline {highlight}{Highlighted\nobreakspace {}(AF)}{highlighted text}{167}
+\ChangesListline {added}{Added\nobreakspace {}(AF)}{Added text}{vii}
+\ChangesListline {deleted}{Deleted\nobreakspace {}(WS)}{Here is the text to be deleted}{vii}
+\ChangesListline {replaced}{Replaced\nobreakspace {}(CS)}{new text}{vii}
+\ChangesListline {highlight}{Highlighted\nobreakspace {}(AF)}{highlighted text}{vii}

--- a/Standard/appendix.tex
+++ b/Standard/appendix.tex
@@ -11,6 +11,4 @@
 \chapter{CoreASM PASS Reference Implementation}
 \label{CoreASM-Reference-Implementation}
 
-%verursacht schwere Fehler in der PDF Struktur
-%Syntax Error: Couldn't read xref table Syntax Warning: PDF file is damaged - attempting to reconstruct xref table...
-%\input{appendixC}
+\input{appendixC}


### PR DESCRIPTION
- The error "Syntax Error: Couldn't read xref table" seems to be caused by the file ArchitekturKonsoleCoreASM.pdf. I re-generated that file and don't see the error anymore.
- I also fixed some syntax errors and warnings in the bibliography. A lot of warnings remain, mostly repeated entries.